### PR TITLE
chore:서버 재시작 위한 워크플로우 추가

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -1,0 +1,26 @@
+name: 수동 Spring Boot 서버 재시작
+
+on:
+  workflow_dispatch:
+
+jobs:
+  RestartOnly:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Spring Boot 재시작
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.NCP_HOST }}
+          username: ${{ secrets.NCP_USERNAME }}
+          password: ${{ secrets.NCP_PASSWORD }}
+          script_stop: true
+          script: |
+            echo "기존 프로세스를 종료하고 재시작."
+            sudo fuser -k -n tcp 8080 || true
+
+            echo "Spring Boot 다시 실행합니다."
+            cd /home/ubuntu/matchday-server/current
+            nohup java -jar project.jar > ./output.log 2>&1 &
+
+            echo "재시작 완료"

--- a/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
+++ b/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
         userRepository.save(user);
     }
 
-    //유저 이름 중복 체크
+    //유저 이름 중복 체크.
     private void validateDuplicateUser(String name) {
         if (userRepository.existsByName(name)) {
             throw new ApiException(UserStatus.DUPLICATE_NAME);


### PR DESCRIPTION
## Related Issue

X,운영 편의 목적의 워크플로우 추가

## Overview

- GitHub Actions 수동 실행용 `restart-server.yml` 워크플로우 추가
- 서버에 배포된 JAR 파일을 재시작하는 기능만 수행
- `workflow_dispatch` 트리거로 수동 실행 가능





