### PR TITLE
fix(application.yml):hibernate 방언 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        dialect: org.hibernate.dialect.MySQLDialect
     show-sql: true
     
 springdoc:


### PR DESCRIPTION
## Related Issue



## Overview

[org.hibernate.engine.jdbc.env.spi.JdbcEnvironment] due to: Unable to determine Dialect without JDBC metadata (please set 'jakarta.persistence.jdbc.url' for common cases or 'hibernate.dialect' when a custom Dialect implementation must be provided)
fix(application.yml):hibernate 오류 해결을 위한

방언 설정 추가

## Screenshot

Optional 




