### PR TITLE
[MAT-27] 팀에 등록된 선수 조회 API 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/team/controller/TeamController.java
+++ b/src/main/java/com/matchday/matchdayserver/team/controller/TeamController.java
@@ -3,11 +3,14 @@ package com.matchday.matchdayserver.team.controller;
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.team.model.dto.request.TeamCreateRequest;
 import com.matchday.matchdayserver.team.model.dto.response.TeamListResponse;
+import com.matchday.matchdayserver.team.model.dto.response.TeamMemberListResponse;
+import com.matchday.matchdayserver.team.model.dto.response.TeamMemberResponse;
 import com.matchday.matchdayserver.team.model.dto.response.TeamNameResponse;
 import com.matchday.matchdayserver.team.service.TeamService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -41,5 +44,11 @@ public class TeamController {
         List<TeamNameResponse> teamList = teamService.getAllTeams();
         TeamListResponse response = new TeamListResponse(teamList);
         return ApiResponse.ok(response);
+    }
+
+    @Operation(summary = "팀에 속한 맴버 리스트 조회")
+    @GetMapping("/{teamId}/users")
+    public ApiResponse<TeamMemberListResponse> getTeamMembers(@PathVariable Long teamId) {
+        return ApiResponse.ok(teamService.getTeamMembers(teamId));
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberListResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberListResponse.java
@@ -1,0 +1,16 @@
+package com.matchday.matchdayserver.team.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamMemberListResponse {
+    private List<TeamMemberResponse> TeamMemberResponses;
+}

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberResponse.java
@@ -1,0 +1,24 @@
+package com.matchday.matchdayserver.team.model.dto.response;
+
+import lombok.*;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class TeamMemberResponse {
+    private Long id;
+    private String name;
+    private Integer number;
+    private String defaultPosition;
+    private Boolean isActive; //현재 팀에서 활동 여부
+
+    @Builder
+    public TeamMemberResponse(Long id, String name, Integer number, String defaultPosition, Boolean isActive) {
+        this.id = id;
+        this.name = name;
+        this.number = number;
+        this.defaultPosition = defaultPosition;
+        this.isActive = isActive;
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
+++ b/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
@@ -3,13 +3,21 @@ package com.matchday.matchdayserver.team.service;
 import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.team.model.dto.request.TeamCreateRequest;
+import com.matchday.matchdayserver.team.model.dto.response.TeamMemberListResponse;
+import com.matchday.matchdayserver.team.model.dto.response.TeamMemberResponse;
 import com.matchday.matchdayserver.team.model.dto.response.TeamNameResponse;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
+import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
+import com.matchday.matchdayserver.userteam.model.mapper.UserTeamMapper;
 import com.matchday.matchdayserver.userteam.repository.UserTeamRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -60,5 +68,14 @@ public class TeamService {
         return teams.stream()
                 .map(team -> new TeamNameResponse(team.getId(), team.getName()))
                 .collect(Collectors.toList());
+    }
+
+    //팀에 속한 선수들 조회
+    public TeamMemberListResponse getTeamMembers(Long teamId){
+        List<UserTeam> userTeams = userTeamRepository.findAllByTeamId(teamId);
+        List<TeamMemberResponse> userTeamMembers = userTeams.stream()
+                .map(userTeam -> UserTeamMapper.toTeamMemberResponse(userTeam))
+                .collect(Collectors.toList());
+        return new TeamMemberListResponse(userTeamMembers);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/userteam/model/dto/JoinUserTeamResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/model/dto/JoinUserTeamResponse.java
@@ -1,18 +1,23 @@
 package com.matchday.matchdayserver.userteam.model.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
+@Setter
 @NoArgsConstructor
-@AllArgsConstructor
-@Builder
 public class JoinUserTeamResponse { //팀 입단 성공 후 클라이언트에게 보낼 응답값
     private Long id;
     private String teamName;
     private String userName;
     private Integer number;
     private String defaultPosition;
+
+    @Builder
+    public JoinUserTeamResponse(Long id, String teamName, String userName, Integer number, String defaultPosition) {
+        this.id = id;
+        this.teamName = teamName;
+        this.userName = userName;
+        this.number = number;
+        this.defaultPosition = defaultPosition;
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/userteam/model/mapper/UserTeamMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/model/mapper/UserTeamMapper.java
@@ -1,9 +1,13 @@
 package com.matchday.matchdayserver.userteam.model.mapper;
 
+import com.matchday.matchdayserver.team.model.dto.response.TeamMemberListResponse;
+import com.matchday.matchdayserver.team.model.dto.response.TeamMemberResponse;
+import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.userteam.model.dto.JoinUserTeamResponse;
 import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
 
 public class UserTeamMapper {
+    //userTeam -> JoinUserTeam Response 변환 정적 메소드
     public static JoinUserTeamResponse toJoinUserTeamResponse(UserTeam userTeam) {
         return JoinUserTeamResponse.builder()
                 .id(userTeam.getId())
@@ -11,6 +15,17 @@ public class UserTeamMapper {
                 .teamName(userTeam.getTeam().getName())
                 .number(userTeam.getNumber())
                 .defaultPosition(userTeam.getDefaultPosition())
+                .build();
+    }
+    //userTeam -> TeamMember Response 변환 정적 메소드
+    public static TeamMemberResponse toTeamMemberResponse(UserTeam userTeam) {
+        User user = userTeam.getUser();
+        return TeamMemberResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .number(userTeam.getNumber())
+                .defaultPosition(userTeam.getDefaultPosition())
+                .isActive(userTeam.getIsActive())
                 .build();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
@@ -3,6 +3,9 @@ package com.matchday.matchdayserver.userteam.repository;
 import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     boolean existsByUserIdAndTeamId(Long userId, Long teamId);
+    List<UserTeam> findAllByTeamId(Long teamId);
 }


### PR DESCRIPTION
## Related Issue

[MAT-27](https://match-day.atlassian.net/browse/MAT-27)

## Overview

팀에 등록된 선수 리스트 조회기능 구현

팀에 선수가 많아봐야 50명은 넘지 않을거라 따로 페이징은 하지 않았습니다

## Screenshot

![image](https://github.com/user-attachments/assets/7d7f862b-84d3-41db-8584-393a0cfc32b9)






[MAT-27]: https://match-day.atlassian.net/browse/MAT-27?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ