### PR TITLE
[MAT-39] MatchEvent 엔티티 생성

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.match.model.entity;
 
+import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.FutureOrPresent;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Entity
 @Table(name = "`match`")
@@ -64,5 +66,8 @@ public class Match {
         this.startTime = startTime;
         this.endTime = endTime;
     }
+
+    @OneToMany(mappedBy = "match",cascade = CascadeType.REMOVE)
+    private List<MatchEvent> matchEvents;
 }
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/entity/MatchEvent.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/entity/MatchEvent.java
@@ -1,0 +1,45 @@
+package com.matchday.matchdayserver.matchevent.model.entity;
+
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.user.model.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+public class MatchEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @CreationTimestamp
+    private LocalDateTime eventTime;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false , length = 20) //20글자 넘어가는 ENUM 생기면 수정해줘야함
+    private EventType eventType;
+
+    @Column(length = 400)
+    private String description; // 메모
+
+    public enum EventType {
+        GOAL, ASSIST, SHOT, VALID_SHOT, FOUL, OFFSIDE,
+        SUB_IN, SUB_OUT, YELLOW_CARD, RED_CARD, OWN_GOAL
+        //골,어시스트,슛,유효슛,파울,오프사이드
+        //교체입장,교체퇴장,옐로카드,레드카드(퇴장),자책골
+    }
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) //EAGER 로딩이 필요하다면 변경하시오
+    @JoinColumn(name = "match_id", nullable = false) //명시적으로 외래키 명 지정
+    private Match match;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+}

--- a/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
@@ -1,5 +1,6 @@
     package com.matchday.matchdayserver.user.model.entity;
 
+    import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
     import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
     import jakarta.persistence.*;
     import lombok.Builder;
@@ -30,4 +31,7 @@
 
         @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
         private List<UserTeam> userTeams;
+
+        @OneToMany(mappedBy = "user") // cascade = CascadeType.REMOVE 안한 이유 : 유저의 과거 기록은 남겨두는게 좋을듯?
+        private List<MatchEvent> matchEvents;
     }


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-39

## Overview

Match(경기)에서 발생한 User(선수)의 Event를 기록하는 MatchEvent 엔티티 구현

## Screenshot

![image](https://github.com/user-attachments/assets/246a5f96-568c-4233-baad-e97b0310515a)




