### PR TITLE
[MAT-35] Match Player 등록 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchPlayerStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchPlayerStatus.java
@@ -1,0 +1,32 @@
+package com.matchday.matchdayserver.common.response;
+
+public enum MatchPlayerStatus implements StatusInterface {
+    NOTFOUND_MATCH(400, 7001, "존재하지 않는 매치입니다"),
+    NOTFOUND_USER(400, 7002, "존재하지 않는 유저입니다");
+
+    private final int httpStatusCode;
+    private final int customStatusCode;
+    private final String description;
+
+    MatchPlayerStatus(int httpStatusCode, int customStatusCode, String description) {
+        this.httpStatusCode = httpStatusCode;
+        this.customStatusCode = customStatusCode;
+        this.description = description;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    @Override
+    public int getCustomStatusCode() {
+        return customStatusCode;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}
+

--- a/src/main/java/com/matchday/matchdayserver/matchplayer/controller/MatchPlayerController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchplayer/controller/MatchPlayerController.java
@@ -1,0 +1,25 @@
+package com.matchday.matchdayserver.matchplayer.controller;
+
+import com.matchday.matchdayserver.common.response.ApiResponse;
+import com.matchday.matchdayserver.matchplayer.model.dto.MatchPlayerCreateRequest;
+import com.matchday.matchdayserver.matchplayer.service.MatchPlayerService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "match-players", description = "매치 선수 관련 API")
+@RestController
+@RequestMapping("/api/v1/matches")
+@RequiredArgsConstructor
+public class MatchPlayerController {
+    private final MatchPlayerService matchPlayerService;
+
+    @Operation(summary = "매치 선수 등록")
+    @PostMapping("/{matchId}/players")
+    public ApiResponse<String> createMatch(@PathVariable Long matchId,
+                                           @RequestBody MatchPlayerCreateRequest request) {
+        matchPlayerService.create(matchId, request);
+        return ApiResponse.ok("매치 선수 등록 완료");
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchplayer/model/dto/MatchPlayerCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchplayer/model/dto/MatchPlayerCreateRequest.java
@@ -1,0 +1,11 @@
+package com.matchday.matchdayserver.matchplayer.model.dto;
+
+import com.matchday.matchdayserver.matchplayer.model.entity.MatchPlayer;
+import lombok.Getter;
+
+@Getter
+public class MatchPlayerCreateRequest {
+    private Long userId;
+    private MatchPlayer.Role role;
+    private String match_position;
+}

--- a/src/main/java/com/matchday/matchdayserver/matchplayer/model/entity/MatchPlayer.java
+++ b/src/main/java/com/matchday/matchdayserver/matchplayer/model/entity/MatchPlayer.java
@@ -4,8 +4,12 @@ import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.user.model.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class MatchPlayer {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,7 +31,14 @@ public class MatchPlayer {
     private String matchPosition;
 
     public enum Role {
-        START_PLAYER, SUB_PLAYER
+        start_player, sub_player
     }
 
+    @Builder
+    public MatchPlayer(Match match, User user, Role role, String matchPosition) {
+        this.match = match;
+        this.user = user;
+        this.role = role;
+        this.matchPosition = matchPosition;
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchplayer/service/MatchPlayerService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchplayer/service/MatchPlayerService.java
@@ -1,0 +1,41 @@
+package com.matchday.matchdayserver.matchplayer.service;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchPlayerStatus;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.matchplayer.model.dto.MatchPlayerCreateRequest;
+import com.matchday.matchdayserver.matchplayer.model.entity.MatchPlayer;
+import com.matchday.matchdayserver.matchplayer.repository.MatchPlayerRepository;
+import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchPlayerService {
+    private final MatchPlayerRepository matchPlayerRepository;
+    private final MatchRepository matchRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public Long create(Long matchId, MatchPlayerCreateRequest request){
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new ApiException(MatchPlayerStatus.NOTFOUND_MATCH));
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new ApiException(MatchPlayerStatus.NOTFOUND_USER));
+
+        MatchPlayer matchPlayer = MatchPlayer.builder()
+                .match(match)
+                .user(user)
+                .role(request.getRole())
+                .matchPosition(request.getMatch_position())
+                .build();
+
+        matchPlayerRepository.save(matchPlayer);
+        return matchPlayer.getId();
+    }
+}


### PR DESCRIPTION
## Related Issue
[MAT-35](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-35)

## Overview
매치 플레이어 등록 구현 했습니다.

## Screenshot
[등록 성공]
<img width="859" alt="스크린샷 2025-04-18 오전 12 13 29" src="https://github.com/user-attachments/assets/30c85f29-09e2-4e15-8eea-a2e6ae603feb" />
[예외 처리]
- 미등록 매치일 경우
<img width="853" alt="스크린샷 2025-04-18 오전 12 13 42" src="https://github.com/user-attachments/assets/beca5e7a-7642-4063-975e-c35c77f13826" />
- 등록하고자 하는 선수가 미등록 유저
<img width="857" alt="스크린샷 2025-04-18 오전 12 14 03" src="https://github.com/user-attachments/assets/e85a99ce-3eab-4892-9533-ab20a4c12825" />
일 경우

[MAT-35]: https://match-day.atlassian.net/browse/MAT-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ