### PR TITLE
[MAT-35] Match User 등록 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
@@ -1,8 +1,7 @@
 package com.matchday.matchdayserver.common.response;
 
 public enum MatchUserStatus implements StatusInterface {
-    NOTFOUND_MATCH(400, 7001, "존재하지 않는 매치입니다"),
-    NOTFOUND_USER(400, 7002, "존재하지 않는 유저입니다");
+    NOTFOUND_MATCH(404, 7001, "존재하지 않는 매치입니다");
 
     private final int httpStatusCode;
     private final int customStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
@@ -1,0 +1,31 @@
+package com.matchday.matchdayserver.common.response;
+
+public enum MatchUserStatus implements StatusInterface {
+    NOTFOUND_MATCH(400, 7001, "존재하지 않는 매치입니다"),
+    NOTFOUND_USER(400, 7002, "존재하지 않는 유저입니다");
+
+    private final int httpStatusCode;
+    private final int customStatusCode;
+    private final String description;
+
+    MatchUserStatus(int httpStatusCode, int customStatusCode, String description) {
+        this.httpStatusCode = httpStatusCode;
+        this.customStatusCode = customStatusCode;
+        this.description = description;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    @Override
+    public int getCustomStatusCode() {
+        return customStatusCode;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
@@ -1,0 +1,25 @@
+package com.matchday.matchdayserver.matchuser.controller;
+
+import com.matchday.matchdayserver.common.response.ApiResponse;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.service.MatchUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "match-users", description = "매치 유저 관련 API")
+@RestController
+@RequestMapping("/api/v1/matches")
+@RequiredArgsConstructor
+public class MatchUserController {
+    private final MatchUserService matchPlayerService;
+
+    @Operation(summary = "매치 유저 등록", description = "{matchID}에 사용자(user)가 등록됩니다.")
+    @PostMapping("/{matchId}/users")
+    public ApiResponse<String> createMatch(@PathVariable Long matchId,
+                                           @RequestBody MatchUserCreateRequest request) {
+        matchPlayerService.create(matchId, request);
+        return ApiResponse.ok("매치 유저 등록 완료");
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
@@ -1,0 +1,12 @@
+package com.matchday.matchdayserver.matchuser.model.dto;
+
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import lombok.Getter;
+
+@Getter
+public class MatchUserCreateRequest {
+    private Long userId;
+    private MatchUser.Role role;
+    private String match_position;
+    private String match_grid;
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 public class MatchUserCreateRequest {
     private Long userId;
     private MatchUser.Role role;
-    private String match_position;
-    private String match_grid;
+    private String matchPosition;
+    private String matchGrid;
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -3,8 +3,13 @@ package com.matchday.matchdayserver.matchuser.model.entity;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.user.model.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class MatchUser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,4 +37,12 @@ public class MatchUser {
         admin, start_player, sub_player //감독, 선발선수, 후발선수
     }
 
+    @Builder
+    public MatchUser(Match match, User user, Role role, String matchPosition, String matchGrid) {
+        this.match = match;
+        this.user = user;
+        this.role = role;
+        this.matchPosition = matchPosition;
+        this.matchGrid = matchGrid;
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/mapper/MatchUserMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/mapper/MatchUserMapper.java
@@ -1,0 +1,19 @@
+package com.matchday.matchdayserver.matchuser.model.mapper;
+
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.user.model.entity.User;
+
+public class MatchUserMapper {
+    //MatchUser Dto -> Entity 변환
+    public static MatchUser toMatchUser(Match match, User user, MatchUserCreateRequest request) {
+        return MatchUser.builder()
+                .match(match)
+                .user(user)
+                .role(request.getRole())
+                .matchPosition(request.getMatchPosition())
+                .matchGrid(request.getMatchGrid())
+                .build();
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -2,10 +2,12 @@ package com.matchday.matchdayserver.matchuser.service;
 
 import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.MatchUserStatus;
+import com.matchday.matchdayserver.common.response.UserStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.matchuser.model.mapper.MatchUserMapper;
 import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.repository.UserRepository;
@@ -25,16 +27,9 @@ public class MatchUserService {
         Match match = matchRepository.findById(matchId)
                 .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCH));
         User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_USER));
+                .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
 
-        MatchUser matchPlayer = MatchUser.builder()
-                .match(match)
-                .user(user)
-                .role(request.getRole())
-                .matchPosition(request.getMatchPosition())
-                .matchGrid(request.getMatchGrid())
-                .build();
-
-        matchUserRepository.save(matchPlayer);
+        MatchUser matchUser = MatchUserMapper.toMatchUser(match, user, request);
+        matchUserRepository.save(matchUser);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -1,0 +1,40 @@
+package com.matchday.matchdayserver.matchuser.service;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchUserStatus;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
+import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchUserService {
+    private final MatchUserRepository matchUserRepository;
+    private final MatchRepository matchRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void create(Long matchId, MatchUserCreateRequest request){
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCH));
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_USER));
+
+        MatchUser matchPlayer = MatchUser.builder()
+                .match(match)
+                .user(user)
+                .role(request.getRole())
+                .matchPosition(request.getMatch_position())
+                .matchGrid(request.getMatch_grid())
+                .build();
+
+        matchUserRepository.save(matchPlayer);
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -31,8 +31,8 @@ public class MatchUserService {
                 .match(match)
                 .user(user)
                 .role(request.getRole())
-                .matchPosition(request.getMatch_position())
-                .matchGrid(request.getMatch_grid())
+                .matchPosition(request.getMatchPosition())
+                .matchGrid(request.getMatchGrid())
                 .build();
 
         matchUserRepository.save(matchPlayer);


### PR DESCRIPTION
## Related Issue
[MAT-35](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-35)

## Overview
Match User 등록 구현 했습니다.
전체적인 코드 피드백 주시면 감사하겠습니다.

## Screenshot
[등록 성공]
<img width="727" alt="스크린샷 2025-04-20 오후 9 55 06" src="https://github.com/user-attachments/assets/5a34cf9e-3767-4612-8a6b-d90a26fc1958" />
<img width="437" alt="스크린샷 2025-04-20 오후 9 55 27" src="https://github.com/user-attachments/assets/a577dbe1-b91b-483c-9970-e59df6d07224" />

[예외처리]
- 존재하지 않는 match id일 경우
<img width="728" alt="스크린샷 2025-04-20 오후 9 55 41" src="https://github.com/user-attachments/assets/7323e7d3-432d-4095-98fa-fd4631d58679" />
- 존재하지 않는 user id일 경우
<img width="724" alt="스크린샷 2025-04-20 오후 9 56 04" src="https://github.com/user-attachments/assets/13a41b35-e4ac-491e-881b-3f109e2bfda7" />




[MAT-35]: https://match-day.atlassian.net/browse/MAT-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ