### PR TITLE
fix(workflows): GithubAction

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,9 @@ on:
       - main
     types:
       - closed
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
 
 jobs:
   Deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,7 @@ on:
     branches:
       - release
       - main
-    paths:
-      - '**.java'
-      - 'src/**'
-      - 'build.gradle'
-      - 'settings.gradle'
-      - '.github/workflows/**'
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Related Issue

현재 release 브랜치의 Branch protection rule은 **Test 가 Success 되어야 PR 이 가능**하게 되어있습니다
그러나 소스코드에는 변경이 없어 굳이 빌드 테스트가 불필요해 github action 코드 분기처리로 Skip 될 경우엔 
Success 가 아니기 때문에 PR 이 불가능한 문제가 있습니다
따라서 Test 자체는 모든 경우에 수행되도록 하고
이후 PR이 merge 되고 실제로 NCP 서버에 배포하는 로직의 경우 단순 readme,gitignore 변경의 경우엔 skip 되도록 하였습니다

## Overview

- readme.md,gitignore 변경은 deploy 하지 않게 수정
- 모든 경우에 test 수행되도록 변경




