### PR TITLE
[MAT-96] Match 정보 조회

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -2,10 +2,14 @@ package com.matchday.matchdayserver.match.controller;
 
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.match.model.dto.request.MatchCreateRequest;
+import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.service.MatchCreateService;
+import com.matchday.matchdayserver.match.service.MatchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,12 +20,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/matches")
 @RequiredArgsConstructor
 public class MatchController {
-    private final MatchCreateService matchService;
+    private final MatchCreateService matchCreateService;
+    private final MatchService matchService;
 
     @Operation(summary = "매치 생성")
     @PostMapping
     public ApiResponse<String> createMatch(@RequestBody MatchCreateRequest request) {
-        matchService.create(request);
+        matchCreateService.create(request);
         return ApiResponse.ok("매치 생성 완료");
+    }
+
+    @GetMapping("/{matchId}")
+    @Operation(summary = "매치 정보 조회")
+    public ApiResponse<MatchInfoResponse> getMatchInfo(@PathVariable Long matchId) {
+      MatchInfoResponse response = matchService.getMatchInfo(matchId);
+      return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchCreateRequest.java
@@ -1,6 +1,7 @@
 package com.matchday.matchdayserver.match.model.dto.request;
 
 import com.matchday.matchdayserver.match.model.entity.Match;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -8,13 +9,39 @@ import java.time.LocalTime;
 
 @Getter
 public class MatchCreateRequest {
-    private String title;
-    private Long homeTeamId;
-    private Long awayTeamId;
-    private Match.MatchType matchType;
-    private String stadium;
-    private LocalDate matchDate;
-    private LocalTime startTime;
-    private LocalTime endTime;
+  @Schema(description = "경기명", example = "경기명")
+  private String title;
 
+  @Schema(description = "홈팀 id", example = "홈팀 id")
+  private Long homeTeamId;
+
+  @Schema(description = "상대팀 id", example = "상대팀 id")
+  private Long awayTeamId;
+
+  @Schema(description = "매치 타입(리그/대회/친선)", example = "매치 타입")
+  private Match.MatchType matchType;
+
+  @Schema(description = "경기장 주소", example = "경기장 주소")
+  private String stadium;
+
+  @Schema(description = "경기 일자", example = "경기 일자")
+  private LocalDate matchDate;
+
+  @Schema(description = "경기 시작 시간", example = "경기 시작 시간")
+  private LocalTime startTime;
+
+  @Schema(description = "경기 종료 시간", example = "경기 종료 시간")
+  private LocalTime endTime;
+
+  @Schema(description = "주심", example = "주심 이름")
+  private String mainRefereeName;
+
+  @Schema(description = "부심1", example = "부심1 이름")
+  private String assistantReferee1;
+
+  @Schema(description = "부심2", example = "부심2 이름")
+  private String assistantReferee2;
+
+  @Schema(description = "대기심", example = "대기심 이름")
+    private String fourthReferee;
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
@@ -1,0 +1,70 @@
+package com.matchday.matchdayserver.match.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class MatchInfoResponse {
+  @Schema(description = "id", example = "매치 id")
+  private Long id;
+
+  //장소
+  @Schema(description = "장소", example = "경기 장소")
+  private String stadium;
+  //날짜
+  @Schema(description = "날짜")
+  private LocalDate matchDate;
+
+  //시작 시간
+  @Schema(description = "시작 시간")
+  private LocalTime startTime;
+
+  //종료 시간
+  @Schema(description = "시작 시간")
+  private LocalTime endTime;
+
+  //주심
+  @Schema(description = "주심", example = "주심")
+  private String mainRefereeName;
+
+  //부심
+  @Schema(description = "부심1", example = "부심1")
+  private String assistantReferee1;
+
+  //부심2
+  @Schema(description = "부심2", example = "부심2")
+  private String assistantReferee2;
+
+  //대기심
+  @Schema(description = "대기심", example = "대기심")
+  private String fourthReferee;
+
+  @Schema(description = "전반 시작 시간")
+  private LocalTime firstHalfStartTime;
+
+  @Schema(description = "후반 시작 시간")
+  private LocalTime secondHalfStartTime;
+
+  @Builder
+  public MatchInfoResponse(Long id, String stadium, LocalDate matchDate, LocalTime startTime,
+      LocalTime endTime, String mainRefereeName, String assistantReferee1,
+      String assistantReferee2, String fourthReferee,
+      LocalTime firstHalfStartTime, LocalTime secondHalfStartTime) {
+    this.id = id;
+    this.stadium = stadium;
+    this.matchDate = matchDate;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.mainRefereeName = mainRefereeName;
+    this.assistantReferee1 = assistantReferee1;
+    this.assistantReferee2 = assistantReferee2;
+    this.fourthReferee = fourthReferee;
+    this.firstHalfStartTime = firstHalfStartTime;
+    this.secondHalfStartTime = secondHalfStartTime;
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -51,20 +51,45 @@ public class Match {
     @Column(nullable = false)
     private LocalTime endTime;
 
-    public enum MatchType {
+    @Column(name = "first_half_start_time")
+    private LocalTime firstHalfStartTime; // 전반 시작 시간
+
+    @Column(name = "second_half_start_time")
+    private LocalTime secondHalfStartTime; // 후반 시작 시간
+
+    @Column(name = "main_referee")
+    private String mainRefereeName; //주심
+
+    @Column(name = "assistant_referee_1")
+    private String assistantReferee1; //부심1
+
+    @Column(name = "assistant_referee_2")
+    private String assistantReferee2; //부심2
+
+    @Column(name = "fourth_referee")
+    private String fourthReferee;  //대기심
+
+  public enum MatchType {
         리그, 대회, 친선경기
     }
 
     @Builder
-    public Match(String title, Team homeTeam, Team awayTeam, MatchType matchType, String stadium, LocalDate matchDate, LocalTime startTime, LocalTime endTime) {
-        this.title = title;
-        this.homeTeam = homeTeam;
-        this.awayTeam = awayTeam;
-        this.matchType = matchType;
-        this.stadium = stadium;
-        this.matchDate = matchDate;
-        this.startTime = startTime;
-        this.endTime = endTime;
+    public Match(String title, Team homeTeam, Team awayTeam, MatchType matchType, String stadium, LocalDate matchDate,
+        LocalTime startTime, LocalTime endTime, LocalTime firstHalfStartTime, LocalTime secondHalfStartTime, String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee) {
+      this.title = title;
+      this.homeTeam = homeTeam;
+      this.awayTeam = awayTeam;
+      this.matchType = matchType;
+      this.stadium = stadium;
+      this.matchDate = matchDate;
+      this.startTime = startTime;
+      this.endTime = endTime;
+      this.firstHalfStartTime = firstHalfStartTime;
+      this.secondHalfStartTime = secondHalfStartTime;
+      this.mainRefereeName = mainRefereeName;
+      this.assistantReferee1 = assistantReferee1;
+      this.assistantReferee2 = assistantReferee2;
+      this.fourthReferee = fourthReferee;
     }
 
     @OneToMany(mappedBy = "match",cascade = CascadeType.REMOVE)

--- a/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
@@ -1,0 +1,23 @@
+package com.matchday.matchdayserver.match.model.mapper;
+
+import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
+import com.matchday.matchdayserver.match.model.entity.Match;
+
+public class MatchMapper {
+  //Match -> MatchInfoResponse 변환
+  public static MatchInfoResponse toResponse(Match match) {
+    return MatchInfoResponse.builder()
+        .id(match.getId())
+        .stadium(match.getStadium())
+        .matchDate(match.getMatchDate())
+        .startTime(match.getStartTime())
+        .endTime(match.getEndTime())
+        .mainRefereeName(match.getMainRefereeName())
+        .assistantReferee1(match.getAssistantReferee1())
+        .assistantReferee2(match.getAssistantReferee2())
+        .fourthReferee(match.getFourthReferee())
+        .firstHalfStartTime(match.getFirstHalfStartTime())
+        .secondHalfStartTime(match.getSecondHalfStartTime())
+        .build();
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
@@ -39,6 +39,10 @@ public class MatchCreateService {
                 .matchDate(request.getMatchDate())
                 .startTime(request.getStartTime())
                 .endTime(request.getEndTime())
+                .mainRefereeName(request.getMainRefereeName())
+                .assistantReferee1(request.getAssistantReferee1())
+                .assistantReferee2(request.getAssistantReferee2())
+                .fourthReferee(request.getFourthReferee())
                 .build();
 
         matchRepository.save(match);

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -1,0 +1,23 @@
+package com.matchday.matchdayserver.match.service;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchStatus;
+import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.model.mapper.MatchMapper;
+import com.matchday.matchdayserver.match.repository.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchService {
+  private final MatchRepository matchRepository;
+
+  public MatchInfoResponse getMatchInfo(Long matchId) {
+    Match match = matchRepository.findById(matchId)
+        .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
+    return MatchMapper.toResponse(match);
+  }
+
+}


### PR DESCRIPTION
## Related Issue

[MAT-96](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-96)

## Overview
매치 정보 조회 API 입니다.
주심, 부심, 대기심 컬럼 추가하여 매치 정보 조회될 수 있게 했습니다.
(전반 시작 시간, 후반 시작 시간도 컬럼 추가는 했는데, 등록을 어떻게 해야할지 고민되어서 해당 부분은 구현하지 않았습니다)

## Screenshot
<img width="510" alt="스크린샷 2025-04-26 오후 2 19 57" src="https://github.com/user-attachments/assets/18cee24e-458c-4483-bcaf-ef968a340afb" />





