### PR TITLE
[MAT-102] 알 수 없는 에러 예외 처리 ApiExceptionHandler 

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
@@ -2,6 +2,7 @@ package com.matchday.matchdayserver.common.exception;
 
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.common.response.DefaultStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,6 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.List;
 
+@Slf4j
 @RestControllerAdvice
 public class ApiExceptionHandler {
 
@@ -35,6 +37,7 @@ public class ApiExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     public ApiResponse<String> handleAllExceptions(Exception ex) {
+      log.error("예외 발생: 타입=[{}], 메시지=[{}]", ex.getClass().getName(), ex.getMessage(), ex);
       return ApiResponse.error(DefaultStatus.UNKNOWN_ERROR);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
@@ -31,4 +31,10 @@ public class ApiExceptionHandler {
 
         return ApiResponse.error(DefaultStatus.BAD_REQUEST, errorMessage); //400 에러 발생 후 각 검증 어노테이션에서 설정한 msg 출력
     }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiResponse<String> handleAllExceptions(Exception ex) {
+      return ApiResponse.error(DefaultStatus.UNKNOWN_ERROR);
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/common/response/DefaultStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/DefaultStatus.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum DefaultStatus implements StatusInterface {
     OK(HttpStatus.OK.value(), HttpStatus.OK.value(), "OK"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), 400, "Wrong Request"),
-    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "Server Error"),
+    UNKNOWN_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), 500, "Unknown Error"),
     ;
 
     private final int httpStatusCode;


### PR DESCRIPTION
## Overview

- ApiExcepiton으로 Throw 되지 않는 경우 알 수 없는 에러 핸들링 처리 
- DefaultStatusException에서 사용하지 않는 SERVER_ERROR 삭제

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 예기치 않은 오류 발생 시, 표준화된 에러 응답과 함께 내부 서버 오류 메시지가 반환되도록 개선되었습니다.

- **스타일**
  - 에러 메시지에 사용되는 용어가 "Server Error"에서 "Unknown Error"로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->