### PR TITLE
[MAT-97] Match Event 기록 요구사항에 맞게 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
@@ -34,7 +34,7 @@ public class MatchEventMapper {
         .teamName(team.getName())
         .userId(user.getId())
         .userName(user.getName())
-        .eventLog(MatchEventResponse.generateEventLog(user.getName(), matchEvent.getEventType()))
+        .eventLog(matchEvent.getEventType().value)
         .build();
   }
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventResponse.java
@@ -29,20 +29,4 @@ public class MatchEventResponse {
 
   @Schema(description = "이벤트 로그", example = "손흥민 경고")
   private String eventLog;
-
-  public static String generateEventLog(String userName, MatchEventType eventType) {
-    return switch (eventType) {
-      case GOAL -> userName + " 득점";
-      case ASSIST -> userName + " 어시스트";
-      case SHOT -> userName + " 슛";
-      case VALID_SHOT -> userName + " 유효슛";
-      case FOUL -> userName + " 파울";
-      case OFFSIDE -> userName + " 오프사이드";
-      case SUB_IN -> userName + " 교체 투입";
-      case SUB_OUT -> userName + " 교체 아웃";
-      case YELLOW_CARD -> userName + " 경고";
-      case RED_CARD -> userName + " 퇴장";
-      case OWN_GOAL -> userName + " 자책골";
-    };
-  }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/entity/MatchEvent.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/entity/MatchEvent.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import org.hibernate.annotations.CreationTimestamp;
 
@@ -29,18 +30,28 @@ public class MatchEvent {
     @CreationTimestamp
     private LocalDateTime eventTime;
 
+    @Setter
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false , length = 20) //20글자 넘어가는 ENUM 생기면 수정해줘야함
+    @Column(nullable = false, length = 20) // 20글자 넘어가는 ENUM 생기면 수정해줘야함
     private MatchEventType eventType;
 
     @Column(length = 400)
     private String description; // 메모
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false) //EAGER 로딩이 필요하다면 변경하시오
-    @JoinColumn(name = "match_id", nullable = false) //명시적으로 외래키 명 지정
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) // EAGER 로딩이 필요하다면 변경하시오
+    @JoinColumn(name = "match_id", nullable = false) // 명시적으로 외래키 명 지정
     private Match match;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
+
+    public MatchEvent copyWith(MatchEventType eventType) {
+        return MatchEvent.builder()
+                .eventType(eventType)
+                .description(this.description)
+                .match(this.match)
+                .user(this.user)
+                .build();
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/enums/MatchEventType.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/enums/MatchEventType.java
@@ -5,37 +5,41 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "경기 이벤트 타입")
 public enum MatchEventType {
     @Schema(description = "골")
-    GOAL,
-    
+    GOAL("골"),
+
     @Schema(description = "어시스트")
-    ASSIST,
-    
+    ASSIST("어시스트"),
+
     @Schema(description = "슛")
-    SHOT,
-    
+    SHOT("슛"),
+
     @Schema(description = "유효슛")
-    VALID_SHOT,
-    
+    VALID_SHOT("유효슛"),
+
     @Schema(description = "파울")
-    FOUL,
-    
+    FOUL("파울"),
+
     @Schema(description = "오프사이드")
-    OFFSIDE,
-    
+    OFFSIDE("오프사이드"),
+
     @Schema(description = "교체입장")
-    SUB_IN,
-    
+    SUB_IN("교체입장"),
+
     @Schema(description = "교체퇴장")
-    SUB_OUT,
-    
+    SUB_OUT("교체퇴장"),
+
     @Schema(description = "옐로카드")
-    YELLOW_CARD,
-    
+    YELLOW_CARD("옐로카드"),
+
     @Schema(description = "레드카드(퇴장)")
-    RED_CARD,
-    
+    RED_CARD("퇴장"),
+
     @Schema(description = "자책골")
-    OWN_GOAL
-    //골,어시스트,슛,유효슛,파울,오프사이드
-    //교체입장,교체퇴장,옐로카드,레드카드(퇴장),자책골
+    OWN_GOAL("자책골");
+
+    public final String value;
+
+    MatchEventType(String value) {
+        this.value = value;
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
@@ -1,0 +1,157 @@
+package com.matchday.matchdayserver.matchevent.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.TeamStatus;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
+import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
+import com.matchday.matchdayserver.team.model.entity.Team;
+import com.matchday.matchdayserver.team.repository.TeamRepository;
+import com.matchday.matchdayserver.user.model.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * MatchEventStrategy
+ * <p>
+ * 경기 이벤트 생성 전략 클래스입니다.
+ * <ul>
+ * <li>골 기록 시: 유효슛, 슛 이벤트를 함께 생성</li>
+ * <li>오프사이드 기록 시: 오프사이드, 파울 이벤트를 함께 생성</li>
+ * <li>유효슛 기록 시: 유효슛, 슛 이벤트를 함께 생성</li>
+ * </ul>
+ * <p>
+ * 트랜잭션 처리는 상위 서비스에서 담당해야 합니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MatchEventStrategy {
+
+  private final MatchEventRepository matchEventRepository;
+  private final TeamRepository teamRepository;
+
+  public List<MatchEventResponse> generateMatchEventLog(MatchEventRequest request, Match match, User user) {
+    return generateMatchEvent(request, match, user);
+  }
+
+  private List<MatchEventResponse> generateMatchEvent(MatchEventRequest request, Match match, User user) {
+    switch (request.getEventType()) {
+      case GOAL:
+        return generateGoalEvent(request, match, user);
+      case OFFSIDE:
+        return generateOffsideEvent(request, match, user);
+      case VALID_SHOT:
+        return generateValidShotEvent(request, match, user);
+      default:
+        return generateDefaultEvent(request, match, user);
+    }
+  }
+
+  /**
+   * 골 이벤트 기록 시 호출됩니다.
+   * <ul>
+   * <li>실제 골 이벤트(goalEvent)를 생성합니다.</li>
+   * <li>골 이벤트를 기반으로 슛(shotEvent), 유효슛(validShotEvent) 이벤트를 각각 복사 생성합니다.</li>
+   * <li>세 이벤트를 모두 저장하고, 각각의 응답 객체를 반환합니다.</li>
+   * </ul>
+   * 
+   * @param request 골 이벤트 요청 정보
+   * @param match   해당 경기 정보
+   * @param user    이벤트를 기록한 사용자
+   * @return 생성된 이벤트들의 응답 리스트 (골, 슛, 유효슛)
+   */
+  private List<MatchEventResponse> generateGoalEvent(MatchEventRequest request, Match match, User user) {
+    MatchEvent goalEvent = MatchEventMapper.toEntity(request, match, user);
+    MatchEvent shotEvent = goalEvent.copyWith(MatchEventType.SHOT);
+    MatchEvent validShotEvent = goalEvent.copyWith(MatchEventType.VALID_SHOT);
+    matchEventRepository.saveAll(List.of(goalEvent, shotEvent, validShotEvent));
+
+    List<MatchEventResponse> matchEventResponses = new ArrayList<>();
+    Team team = findByMatchIdAndUserIdOrThrow(match, user);
+    matchEventResponses.add(MatchEventMapper.toResponse(goalEvent, team));
+    matchEventResponses.add(MatchEventMapper.toResponse(shotEvent, team));
+    matchEventResponses.add(MatchEventMapper.toResponse(validShotEvent, team));
+
+    return matchEventResponses;
+  }
+
+  /**
+   * 오프사이드 이벤트 기록 시 호출됩니다.
+   * <ul>
+   * <li>오프사이드 이벤트(offsideEvent)를 생성합니다.</li>
+   * <li>오프사이드 이벤트를 기반으로 파울(foulEvent) 이벤트를 복사 생성합니다.</li>
+   * <li>두 이벤트를 모두 저장하고, 각각의 응답 객체를 반환합니다.</li>
+   * </ul>
+   * 
+   * @param request 오프사이드 이벤트 요청 정보
+   * @param match   해당 경기 정보
+   * @param user    이벤트를 기록한 사용자
+   * @return 생성된 이벤트들의 응답 리스트 (오프사이드, 파울)
+   */
+  private List<MatchEventResponse> generateOffsideEvent(MatchEventRequest request, Match match, User user) {
+    MatchEvent offsideEvent = MatchEventMapper.toEntity(request, match, user);
+    MatchEvent foulEvent = offsideEvent.copyWith(MatchEventType.FOUL);
+    matchEventRepository.saveAll(List.of(offsideEvent, foulEvent));
+    Team team = findByMatchIdAndUserIdOrThrow(match, user);
+    return List.of(
+        MatchEventMapper.toResponse(offsideEvent, team),
+        MatchEventMapper.toResponse(foulEvent, team));
+  }
+
+  /**
+   * 유효슛 이벤트 기록 시 호출됩니다.
+   * <ul>
+   * <li>유효슛 이벤트(validShotEvent)를 생성합니다.</li>
+   * <li>유효슛 이벤트를 기반으로 슛(shotEvent) 이벤트를 복사 생성합니다.</li>
+   * <li>두 이벤트를 모두 저장하고, 각각의 응답 객체를 반환합니다.</li>
+   * </ul>
+   * 
+   * @param request 유효슛 이벤트 요청 정보
+   * @param match   해당 경기 정보
+   * @param user    이벤트를 기록한 사용자
+   * @return 생성된 이벤트들의 응답 리스트 (유효슛, 슛)
+   */
+  private List<MatchEventResponse> generateValidShotEvent(MatchEventRequest request, Match match, User user) {
+    MatchEvent validShotEvent = MatchEventMapper.toEntity(request, match, user);
+    MatchEvent shotEvent = validShotEvent.copyWith(MatchEventType.SHOT);
+    matchEventRepository.saveAll(List.of(validShotEvent, shotEvent));
+    Team team = findByMatchIdAndUserIdOrThrow(match, user);
+    return List.of(
+        MatchEventMapper.toResponse(validShotEvent, team),
+        MatchEventMapper.toResponse(shotEvent, team));
+  }
+
+  /**
+   * 기타 이벤트(기본 이벤트) 기록 시 호출됩니다.
+   * <ul>
+   * <li>요청에 따라 단일 MatchEvent를 생성 및 저장합니다.</li>
+   * <li>이벤트에 대한 응답 객체를 반환합니다.</li>
+   * </ul>
+   * 
+   * @param request 기타 이벤트 요청 정보
+   * @param match   해당 경기 정보
+   * @param user    이벤트를 기록한 사용자
+   * @return 생성된 이벤트의 응답 리스트 (단일 이벤트)
+   */
+  private List<MatchEventResponse> generateDefaultEvent(MatchEventRequest request, Match match, User user) {
+    MatchEvent matchEvent = MatchEventMapper.toEntity(request, match, user);
+    matchEventRepository.save(matchEvent);
+    Team team = findByMatchIdAndUserIdOrThrow(match, user);
+    return List.of(MatchEventMapper.toResponse(matchEvent, team));
+  }
+
+  private Team findByMatchIdAndUserIdOrThrow(Match match, User user) {
+    Team team = teamRepository.findByMatchIdAndUserId(match.getId(), user.getId()).orElseThrow(
+        () -> new ApiException(TeamStatus.NOTFOUND_TEAM));
+    return team;
+  }
+}


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-97

## Overview

- EventType value 추가 
- 골 기록시 유효슛, 슛 기록 되도록 변경
- 유효슛 기록시 슛 기록 되도록 변경
- Offside 기록시 Four 기록되게 변경

## Screenshot

<img src="https://github.com/user-attachments/assets/42edf0ff-1dcd-4c14-8be3-7cae1aa4adf5" width="50%"/>





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 다양한 경기 이벤트 유형에 따라 여러 이벤트 로그를 생성하고 반환하는 새로운 이벤트 전략 기능이 추가되었습니다.

- **버그 수정**
  - 이벤트 로그에 사용자 이름이 더 이상 포함되지 않고, 이벤트 유형의 한글 설명이 직접 표시됩니다.

- **리팩터링**
  - 이벤트 처리 로직이 새로운 전략 컴포넌트로 분리되어 관리가 용이해졌습니다.
  - 이벤트 타입에 한글 설명이 추가되어 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->