### PR TITLE
[MAT-129] Team 컬러 추가 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/team/controller/TeamController.java
+++ b/src/main/java/com/matchday/matchdayserver/team/controller/TeamController.java
@@ -26,7 +26,7 @@ public class TeamController {
     private final S3PresignedService s3PresignedManager;
     private static final String FOLDER_NAME = "teams";
 
-    @Operation(summary = "팀 생성", description = "팀 생성 API입니다. ")
+    @Operation(summary = "팀 생성", description = "팀 생성 API입니다. <br> 컬러는 모두 Hex Code로 입력 해주세요.")
     @PostMapping
     public ApiResponse<Long> createTeam(@RequestBody @Valid TeamCreateRequest request) {
         Long teamId = teamService.create(request);

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
@@ -20,7 +20,7 @@ public class TeamCreateRequest {
     @NotBlank(message = "팀 하의 컬러는 필수입니다.")
     private String bottomColor; //팀 하의 컬러
 
-    @Schema(description = "팀 스타킹 컬러)", example = "#FFFFFF", required = true)
-    @NotBlank(message = "팀 스타킹 컬리는 필수입니다.")
+    @Schema(description = "팀 스타킹 컬러", example = "#FFFFFF", required = true)
+    @NotBlank(message = "팀 스타킹 컬러는 필수입니다.")
     private String stockingColor; //팀 스타킹 컬러
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
@@ -12,7 +12,15 @@ public class TeamCreateRequest {
     @NotBlank(message = "팀 명은 필수입니다.")
     private String name; //팀명
 
-    @Schema(description = "팀 컬러(Hex code)", example = "#FFFFFF", required = true)
-    @NotBlank(message = "팀 컬러는 필수입니다.")
-    private String teamColor; //팀 컬러
+    @Schema(description = "팀 컬러(상의 컬러)", example = "#FFFFFF", required = true)
+    @NotBlank(message = "팀 컬러(상의 컬러)는 필수입니다.")
+    private String teamColor; //팀 컬러(상의 컬러)
+
+    @Schema(description = "팀 하의 컬러", example = "#FFFFFF", required = true)
+    @NotBlank(message = "팀 하의 컬러는 필수입니다.")
+    private String bottomColor; //팀 하의 컬러
+
+    @Schema(description = "팀 스타킹 컬러)", example = "#FFFFFF", required = true)
+    @NotBlank(message = "팀 스타킹 컬리는 필수입니다.")
+    private String stockingColor; //팀 스타킹 컬러
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamResponse.java
@@ -9,11 +9,15 @@ public class TeamResponse {
     private Long id;
     private String name;
     private String teamColor;
+    private String bottomColor;
+    private String stockingColor;
 
     @Builder
-    public TeamResponse(Long id, String name, String teamColor) {
+    public TeamResponse(Long id, String name, String teamColor, String bottomColor, String stockingColor) {
         this.id = id;
         this.name = name;
         this.teamColor = teamColor;
+        this.bottomColor = bottomColor;
+        this.stockingColor = stockingColor;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
@@ -26,9 +26,16 @@ public class Team {
     private LocalDateTime createdAt;
 
     @Column(nullable = false)
-    private String teamColor;
+    private String teamColor;  //팀 컬러(상의 컬러)
 
-    @Builder
+    @Column(nullable = false)
+    private String bottomColor; //팀 하의 컬러
+
+    @Column(nullable = false)
+    private String stockingColor; //팀 스타킹 컬러
+
+
+  @Builder
     public Team (String name, String teamColor) {
         this.name = name;
         this.teamColor = teamColor;

--- a/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
@@ -36,9 +36,11 @@ public class Team {
 
 
   @Builder
-    public Team (String name, String teamColor) {
+    public Team (String name, String teamColor, String bottomColor, String stockingColor) {
         this.name = name;
         this.teamColor = teamColor;
+        this.bottomColor = bottomColor;
+        this.stockingColor = stockingColor;
     }
 
     public void updateName(String name) {

--- a/src/main/java/com/matchday/matchdayserver/team/model/mapper/TeamMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/mapper/TeamMapper.java
@@ -14,6 +14,8 @@ public class TeamMapper {
                 .id(team.getId())
                 .name(team.getName())
                 .teamColor(team.getTeamColor())
+                .bottomColor(team.getBottomColor())
+                .stockingColor(team.getStockingColor())
                 .build();
     }
 

--- a/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
+++ b/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
@@ -26,7 +26,7 @@ public class TeamService {
     //팀 생성
     public Long create(TeamCreateRequest request){
         validateDuplicateTeamName(request.getName());
-        Team team = new Team(request.getName(), request.getTeamColor());
+        Team team = new Team(request.getName(), request.getTeamColor(), request.getBottomColor(), request.getStockingColor());
         teamRepository.save(team);
         return team.getId();
     }


### PR DESCRIPTION
## Related Issue
[MAT-129](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-129)

## Overview
1. 팀 엔티티에 하의, 스타킹 컬러 추가
2. 팀 등록 시 하의, 스타킹 컬러 추가 하도록 수정
3. 팀 조회 시 하의, 스타킹 컬러 포함하여 응답하도록 수정

## Screenshot
[팀 등록]
<img width="761" alt="스크린샷 2025-04-30 오후 3 08 48" src="https://github.com/user-attachments/assets/5697b2d3-2573-4c0e-bb78-830d238639e5" />
[팀 조회]
<img width="759" alt="스크린샷 2025-04-30 오후 3 09 03" src="https://github.com/user-attachments/assets/0f8e5df5-88a1-4ff0-8802-20c5b2a1c0c8" />
[DB]
<img width="573" alt="스크린샷 2025-04-30 오후 3 09 28" src="https://github.com/user-attachments/assets/3c8ac7b7-c6b2-4b0e-8328-a0103abe970d" />

Optional 






[MAT-129]: https://match-day.atlassian.net/browse/MAT-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 팀 생성 시 상의, 하의, 스타킹 색상을 각각 별도로 입력할 수 있도록 확장되었습니다. 모든 색상 값은 Hex 코드로 입력해야 합니다.
- **개선 사항**
  - 팀 생성 및 조회 API에서 상의, 하의, 스타킹 컬러 정보를 모두 확인할 수 있습니다.
  - API 문서에 색상 입력 방식(HEX 코드) 안내가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->