### PR TITLE
[MAT-136] 팀 별 경기 출전하는 선수 명단 조회 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ out/
 # 민감정보
 .env
 .DS_Store
+**/application_dev.yml

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'p6spy:p6spy:3.9.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
@@ -11,6 +11,7 @@ public enum MatchStatus implements StatusInterface {
     NOT_PARTICIPATING_PLAYER(400, 6008, "경기에 참여중이지 않은 선수입니다"),
     UNAUTHORIZED_RECORD(403, 6009, "기록할 수 없는 유저입니다"),
     SOCKET_ERROR(500, 6010, "웹소켓 오류"),
+    TEAM_NOT_PARTICIPATING(400, 6011, "해당 팀은 입력받은 경기의 홈팀도, 어웨이팀도 아닙니다."),
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/common/response/UserTeamStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/UserTeamStatus.java
@@ -1,0 +1,30 @@
+package com.matchday.matchdayserver.common.response;
+
+public enum UserTeamStatus implements StatusInterface{
+  NOTFOUND_TEAMUSER(400, 8001, "팀 유저간 소속관계가 없음");
+
+  private final int httpStatusCode;
+  private final int customStatusCode;
+  private final String description;
+
+  UserTeamStatus(int httpStatusCode, int customStatusCode, String description) {
+    this.httpStatusCode = httpStatusCode;
+    this.customStatusCode = customStatusCode;
+    this.description = description;
+  }
+
+  @Override
+  public int getHttpStatusCode() {
+    return this.httpStatusCode;
+  }
+
+  @Override
+  public int getCustomStatusCode() {
+    return this.customStatusCode;
+  }
+
+  @Override
+  public String getDescription() {
+    return this.description;
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
@@ -13,6 +13,12 @@ public class MatchInfoResponse {
   @Schema(description = "id", example = "매치 id")
   private Long id;
 
+  @Schema(description = "홈팀 ID")
+  private Long homeTeamId;
+
+  @Schema(description = "어웨이팀 ID")
+  private Long awayTeamId;
+
   //장소
   @Schema(description = "장소", example = "경기 장소")
   private String stadium;
@@ -54,7 +60,8 @@ public class MatchInfoResponse {
   public MatchInfoResponse(Long id, String stadium, LocalDate matchDate, LocalTime startTime,
       LocalTime endTime, String mainRefereeName, String assistantReferee1,
       String assistantReferee2, String fourthReferee,
-      LocalTime firstHalfStartTime, LocalTime secondHalfStartTime) {
+      LocalTime firstHalfStartTime, LocalTime secondHalfStartTime,
+      Long homeTeamId, Long awayTeamId) {
     this.id = id;
     this.stadium = stadium;
     this.matchDate = matchDate;
@@ -66,5 +73,7 @@ public class MatchInfoResponse {
     this.fourthReferee = fourthReferee;
     this.firstHalfStartTime = firstHalfStartTime;
     this.secondHalfStartTime = secondHalfStartTime;
+    this.homeTeamId = homeTeamId;
+    this.awayTeamId = awayTeamId;
   }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
@@ -4,7 +4,6 @@ import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.model.entity.Match;
 
 public class MatchMapper {
-  //Match -> MatchInfoResponse 변환
   public static MatchInfoResponse toResponse(Match match) {
     return MatchInfoResponse.builder()
         .id(match.getId())
@@ -18,6 +17,8 @@ public class MatchMapper {
         .fourthReferee(match.getFourthReferee())
         .firstHalfStartTime(match.getFirstHalfStartTime())
         .secondHalfStartTime(match.getSecondHalfStartTime())
+        .homeTeamId(match.getHomeTeam().getId()) // 추가
+        .awayTeamId(match.getAwayTeam().getId()) // 추가
         .build();
   }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/EventTypeCount.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/EventTypeCount.java
@@ -1,0 +1,6 @@
+package com.matchday.matchdayserver.matchevent.model.dto;
+
+public interface EventTypeCount {//쿼리 결과를 맵핑시키기 위해 사용 (인터페이스 DTO)
+  String getEventType();
+  Long getCount();
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -1,7 +1,21 @@
 package com.matchday.matchdayserver.matchevent.repository;
 
+import com.matchday.matchdayserver.matchevent.model.dto.EventTypeCount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
-public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> { }
+public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
+  @Query(value = """
+    SELECT 
+      event_type AS eventType,
+      COUNT(*) AS count
+    FROM match_event
+    WHERE match_id = :matchId AND user_id = :userId
+    GROUP BY event_type
+    """, nativeQuery = true)
+  List<EventTypeCount> countEventTypesByUserAndMatch(@Param("matchId") Long matchId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -1,0 +1,48 @@
+package com.matchday.matchdayserver.matchevent.service;
+
+import com.matchday.matchdayserver.matchevent.model.dto.EventTypeCount;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserEventStat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MatchEventQueryService {
+
+  private MatchEventRepository matchEventRepository;
+  /**
+   * MatchEventStrategy
+   * <p>
+   * 특정 경기에서 특정 선수에 대한 득점,어시스트,파울 개수를 조회합니다
+   * <p>
+   */
+  public MatchUserEventStat getMatchUserEventStat(Long matchId,Long userId) {
+    int goals=0;
+    int assists=0;
+    int fouls=0;
+
+    //쿼리 결과 받아서 변수에 대입
+    List<EventTypeCount> eventTypeCounts= matchEventRepository.countEventTypesByUserAndMatch(matchId,userId);
+    for (EventTypeCount eventTypeCount : eventTypeCounts) {
+      String eventType = eventTypeCount.getEventType();
+      Long count = eventTypeCount.getCount();
+
+      if ("GOALS".equals(eventType)) {
+        goals = count.intValue();
+      } else if ("ASSISTS".equals(eventType)) {
+        assists = count.intValue();
+      } else if ("FOULS".equals(eventType)) {
+        fouls = count.intValue();
+      }
+    }
+
+    //쿼리로 얻은 변수로 DTO 만들어 결과값으로 리턴
+    return MatchUserEventStat.builder().
+        goals(goals).
+        assists(assists).
+        fouls(fouls).
+        build();
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -11,7 +11,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MatchEventQueryService {
 
-  private MatchEventRepository matchEventRepository;
+  private final MatchEventRepository matchEventRepository;
   /**
    * MatchEventStrategy
    * <p>

--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
@@ -25,10 +25,11 @@ public class MatchUserController {
         return ApiResponse.ok("매치 유저 등록 완료");
     }
 
-    @GetMapping("/{matchId}/participants")
-    public ApiResponse<List<MatchUserResponse>> getMatchUsers(@PathVariable Long matchId,@RequestParam Long teamId,@RequestParam String role) {
+    @Operation(summary = "매치에 출전한 선수들 조회", description = "경기 id 와 조회할 팀 id를 요청받습니다")
+    @GetMapping("/{matchId}/players")
+    public ApiResponse<List<MatchUserResponse>> getMatchUsers(@PathVariable Long matchId,@RequestParam Long teamId) {
       //todo 특정 role에 대해서만 조회 teamid 어떻게 할지
-      ApiResponse<List<MatchUserResponse>> = matchUserService.getMatchUser(matchId);
-
+      List<MatchUserResponse> MatchUserResponses =  matchUserService.getMatchUsers(matchId,teamId);
+      return ApiResponse.ok(MatchUserResponses);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
@@ -2,24 +2,33 @@ package com.matchday.matchdayserver.matchuser.controller;
 
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserResponse;
 import com.matchday.matchdayserver.matchuser.service.MatchUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @Tag(name = "match-users", description = "매치 유저 관련 API")
 @RestController
 @RequestMapping("/api/v1/matches")
 @RequiredArgsConstructor
 public class MatchUserController {
-    private final MatchUserService matchPlayerService;
+    private final MatchUserService matchUserService;
 
     @Operation(summary = "매치 유저 등록", description = "{matchID}에 사용자(user)가 등록됩니다.")
     @PostMapping("/{matchId}/users")
     public ApiResponse<String> createMatch(@PathVariable Long matchId,
                                            @RequestBody MatchUserCreateRequest request) {
-        matchPlayerService.create(matchId, request);
+      matchUserService.create(matchId, request);
         return ApiResponse.ok("매치 유저 등록 완료");
+    }
+
+    @GetMapping("/{matchId}/participants")
+    public ApiResponse<List<MatchUserResponse>> getMatchUsers(@PathVariable Long matchId,@RequestParam Long teamId,@RequestParam String role) {
+      //todo 특정 role에 대해서만 조회 teamid 어떻게 할지
+      ApiResponse<List<MatchUserResponse>> = matchUserService.getMatchUser(matchId);
+
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
@@ -1,0 +1,21 @@
+package com.matchday.matchdayserver.matchuser.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatchUserEventStat {
+  //MatchEventQueryService에서 MatchUserService로 선수별 주요 이벤트 통계 데이터 전달 시 사용합니다
+  private Integer goals;
+  private Integer assists;
+  private Integer fouls;
+
+  @Builder
+  public MatchUserEventStat(Integer goals, Integer assists, Integer fouls) {
+    this.goals = goals;
+    this.assists = assists;
+    this.fouls = fouls;
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.matchuser.model.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,12 +8,26 @@ import lombok.Setter;
 @Setter
 public class MatchUserResponse {
 
-  private Long id;
+  private Long id; //선수의 아이디
   private String name; //이름
   //축구 선수에게만 필요한 필드
   private Integer number; //등번호
   private String matchPosition; // 주의: defaultPosition 과 matchPostition은 다름
+  private String matchGrid;
+
   private Integer goals;        // 누적 득점
   private Integer assists;      // 누적 어시스트
   private Integer fouls;        // 누적 파울
+
+  @Builder
+  public MatchUserResponse(Long id,String name,Integer number, String matchPosition, String matchGrid, Integer goals, Integer assists, Integer fouls) {
+    this.id = id;
+    this.name = name;
+    this.number = number;
+    this.matchPosition = matchPosition;
+    this.matchGrid = matchGrid;
+    this.goals = goals;
+    this.assists = assists;
+    this.fouls = fouls;
+  }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -1,0 +1,18 @@
+package com.matchday.matchdayserver.matchuser.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatchUserResponse {
+
+  private Long id;
+  private String name; //이름
+  //축구 선수에게만 필요한 필드
+  private Integer number; //등번호
+  private String matchPosition; // 주의: defaultPosition 과 matchPostition은 다름
+  private Integer goals;        // 누적 득점
+  private Integer assists;      // 누적 어시스트
+  private Integer fouls;        // 누적 파울
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/mapper/MatchUserMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/mapper/MatchUserMapper.java
@@ -2,8 +2,11 @@ package com.matchday.matchdayserver.matchuser.model.mapper;
 
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserEventStat;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserResponse;
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
 import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
 
 public class MatchUserMapper {
     //MatchUser Dto -> Entity 변환
@@ -15,5 +18,19 @@ public class MatchUserMapper {
                 .matchPosition(request.getMatchPosition())
                 .matchGrid(request.getMatchGrid())
                 .build();
+    }
+
+    // MatchUser + UserTeam + EventStat → MatchUserResponse (DTO)변환
+    public static MatchUserResponse toMatchUserResponse(MatchUser matchUser, UserTeam userTeam, MatchUserEventStat stat) {
+      return MatchUserResponse.builder()
+          .id(matchUser.getUser().getId())
+          .name(matchUser.getUser().getName())
+          .number(userTeam.getNumber())
+          .matchPosition(matchUser.getMatchPosition())
+          .matchGrid(matchUser.getMatchGrid())
+          .goals(stat.getGoals())
+          .assists(stat.getAssists())
+          .fouls(stat.getFouls())
+          .build();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -1,10 +1,12 @@
 package com.matchday.matchdayserver.matchuser.repository;
 
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
@@ -13,4 +15,6 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
       "JOIN FETCH mu.user u " +
       "WHERE mu.match.id = :matchId AND mu.user.id = :userId")
   Optional<MatchUser> findByMatchIdAndUserIdWithFetch(@Param("matchId") Long matchId, @Param("userId") Long userId);
+
+  List<MatchUser> findByMatchId(Long matchId);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -5,15 +5,24 @@ import com.matchday.matchdayserver.common.response.MatchUserStatus;
 import com.matchday.matchdayserver.common.response.UserStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.matchevent.service.MatchEventQueryService;
+import com.matchday.matchdayserver.matchevent.service.MatchEventStrategy;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserEventStat;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserResponse;
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
 import com.matchday.matchdayserver.matchuser.model.mapper.MatchUserMapper;
 import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.repository.UserRepository;
+import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
+import com.matchday.matchdayserver.userteam.repository.UserTeamRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +30,8 @@ public class MatchUserService {
     private final MatchUserRepository matchUserRepository;
     private final MatchRepository matchRepository;
     private final UserRepository userRepository;
+    private final MatchEventQueryService matchEventQueryService;
+    private final MatchEventStrategy matchEventStrategy;
 
     @Transactional
     public void create(Long matchId, MatchUserCreateRequest request){
@@ -31,5 +42,47 @@ public class MatchUserService {
 
         MatchUser matchUser = MatchUserMapper.toMatchUser(match, user, request);
         matchUserRepository.save(matchUser);
+    }
+
+    //매치에 속한 선수들의 정보들을 조회
+    public List<MatchUserResponse> getMatchUser(Long matchId){
+      List<MatchUserResponse> matchUserResponses = new ArrayList<>();
+      //매치에 속한 유저 정보를 받아온다
+      List<MatchUser> matchUsers = matchUserRepository.findByMatchId(matchId);
+      //해당 유저의 id를 이용해 유저별 이벤트 통계를 조회해 추가해서 matchUserResponses 만든다
+      for(MatchUser matchUser: matchUsers){
+
+        // User
+        Long userId=matchUser.getUser().getId();//선수 고유 아이디//todo: N+1 문제 발생 fetch join 해주기
+        String userName=matchUser.getUser().getName();//선수 이름
+
+        // userTeam
+        Long TeamId=matchUser.getMatch().getId().get
+        UserTeam userTeam=matchEventStrategy.findByMatchIdAndUserIdOrThrow
+        Integer number=userTeam.getNumber();// 등번호 number
+
+        // MatchUserEventStat
+        MatchUserEventStat matchUserEventStat=matchEventQueryService.getMatchUserEventStat(matchId,userId);
+        int goals=matchUserEventStat.getGoals();// 해당 경기에서 누적 득점
+        int assists=matchUserEventStat.getAssists();// 해당 경기에서 누적 어시스트
+        int fouls=matchUserEventStat.getFouls();// 해당 경기에서 누적 파울
+
+        // matchUser
+        String matchPosistion=matchUser.getMatchPosition();// 경기 포지션 matchPosition
+        String matchGrid=matchUser.getMatchGrid();// 경기 세부 위치 matchGrid
+
+        MatchUserResponse matchUserResponse=MatchUserResponse.builder().
+            id(userId).
+            name(userName).
+            number(number).
+            goals(goals).
+            assists(assists).
+            fouls(fouls).
+            matchPosition(matchPosistion).
+            matchGrid(matchGrid).
+            build();
+        matchUserResponses.add(matchUserResponse);
+      }
+      return matchUserResponses;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
@@ -1,11 +1,15 @@
 package com.matchday.matchdayserver.userteam.repository;
 
+import com.matchday.matchdayserver.team.model.entity.Team;
+import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     boolean existsByUserIdAndTeamId(Long userId, Long teamId);
     List<UserTeam> findAllByTeamId(Long teamId);
+    Optional<UserTeam> findByUserIdAndTeamId(Long userId, Long teamId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,6 +22,18 @@ spring:
     init:
       mode: always
 
+  cloud:
+    aws:
+      s3:
+        bucket: ${BUCKET_NAME}         # 변경
+      stack:
+        auto: false
+      region:
+        static: ${AWS_REGION}          # 변경
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}  # 변경
+        secret-key: ${AWS_SECRET_KEY}  # 변경
+
 springdoc:
   api-docs:
     version: "openapi_3_0"

--- a/src/main/resources/spy.properties
+++ b/src/main/resources/spy.properties
@@ -1,0 +1,10 @@
+# ???? ?? ?? ??
+appender=com.p6spy.engine.spy.appender.Slf4JLogger
+logMessageFormat=com.p6spy.engine.spy.appender.MultiLineFormat
+customLogMessageFormat=%(currentTime) | %(executionTime)ms | %(category) | connection%(connectionId) | %(sqlSingleLine)
+
+# ??? ???? (optional)
+excludecategories=info,debug,result,batch
+
+# ?? ?? ??
+loglevel=TRACE


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-136

## Overview

- Match id와 Team id를 입력받아 해당 매치에 출전하는 팀 선수 명단을 조회합니다

## Screenshot
![image](https://github.com/user-attachments/assets/a8072f47-2d84-42a8-9044-356c7c38c0e5)

![image](https://github.com/user-attachments/assets/d328776c-1be8-4b14-a777-9892aa3770c7)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 특정 경기와 팀에 속한 선수 목록 및 상세 정보를 조회하는 API 엔드포인트가 추가되었습니다.
  - 선수별 득점, 어시스트, 파울 등 주요 이벤트 통계를 제공하는 기능이 도입되었습니다.

- **버그 수정**
  - 없음

- **문서화**
  - 없음

- **기타**
  - P6Spy를 통한 SQL 로깅 기능이 추가되어 SQL 쿼리 추적이 가능해졌습니다.
  - 불필요한 파일이 Git 추적에서 제외되었습니다.
  - 빌드 설정에 p6spy 라이브러리 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->