### PR TITLE
[MAT-142] User 정보 조회 API

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
@@ -13,4 +14,10 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
       "JOIN FETCH mu.user u " +
       "WHERE mu.match.id = :matchId AND mu.user.id = :userId")
   Optional<MatchUser> findByMatchIdAndUserIdWithFetch(@Param("matchId") Long matchId, @Param("userId") Long userId);
+
+  // 특정 유저가 참여한 매치 리스트 조회
+  @Query("SELECT mu.match.id FROM MatchUser mu WHERE mu.user.id = :userId")
+  List<Long> findMatchIdsByUserId(@Param("userId") Long userId);
+
+
 }

--- a/src/main/java/com/matchday/matchdayserver/user/controller/UserController.java
+++ b/src/main/java/com/matchday/matchdayserver/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.matchday.matchdayserver.s3.service.S3PresignedService;
 import com.matchday.matchdayserver.s3.dto.S3PresignedResponse;
 import com.matchday.matchdayserver.user.model.dto.request.UserCreateRequest;
 import com.matchday.matchdayserver.user.model.dto.request.UserJoinTeamRequest;
+import com.matchday.matchdayserver.user.model.dto.response.UserInfoResponse;
 import com.matchday.matchdayserver.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -52,4 +53,9 @@ public class UserController {
     return ApiResponse.ok(s3PresignedManager.generateReadUrl(FOLDER_NAME, userId,key));
   }
 
+  @Operation(summary = "유저 정보 조회", description = "유저 정보 조회 API입니다. <br> 특정 유저의 이름, 소속팀 id, 참여한 매치 id를 반환합니다. ")
+  @GetMapping("/{userId}")
+  public ApiResponse<UserInfoResponse> getUserInfo(@PathVariable Long userId){
+    return ApiResponse.ok(userService.getUserInfo(userId));
+  }
 }

--- a/src/main/java/com/matchday/matchdayserver/user/model/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/dto/response/UserInfoResponse.java
@@ -1,0 +1,21 @@
+package com.matchday.matchdayserver.user.model.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+public class UserInfoResponse {
+  private Long userId;
+  private String userName;
+  private List<Long> teamIds;
+  private List<Long> matchIds;
+
+  @Builder
+  public UserInfoResponse(Long userId, String userName ,List<Long> teamIds, List<Long> matchIds) {
+    this.userId = userId;
+    this.userName = userName;
+    this.teamIds = teamIds;
+    this.matchIds = matchIds;
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/user/model/mapper/UserMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/mapper/UserMapper.java
@@ -1,0 +1,17 @@
+package com.matchday.matchdayserver.user.model.mapper;
+
+import com.matchday.matchdayserver.user.model.dto.response.UserInfoResponse;
+import com.matchday.matchdayserver.user.model.entity.User;
+
+import java.util.List;
+
+public class UserMapper {
+  public static UserInfoResponse userInfoResponse(User user, List<Long> teamIds, List<Long> matchIds) {
+    return UserInfoResponse.builder()
+        .userId(user.getId())
+        .userName(user.getName())
+        .teamIds(teamIds)
+        .matchIds(matchIds)
+        .build();
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
+++ b/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
@@ -3,12 +3,17 @@ package com.matchday.matchdayserver.user.service;
 import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.common.response.UserStatus;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
 import com.matchday.matchdayserver.team.service.TeamService;
 import com.matchday.matchdayserver.user.model.dto.request.UserJoinTeamRequest;
+import com.matchday.matchdayserver.user.model.dto.response.UserInfoResponse;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.model.dto.request.UserCreateRequest;
+import com.matchday.matchdayserver.user.model.mapper.UserMapper;
 import com.matchday.matchdayserver.user.repository.UserRepository;
 import com.matchday.matchdayserver.userteam.model.dto.JoinUserTeamResponse;
 import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
@@ -16,6 +21,7 @@ import com.matchday.matchdayserver.userteam.model.mapper.UserTeamMapper;
 import com.matchday.matchdayserver.userteam.repository.UserTeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +31,7 @@ public class UserService {
     private final TeamService teamService;
     private final TeamRepository teamRepository;
     private final UserTeamRepository userTeamRepository;
+    private final MatchUserRepository matchUserRepository;
 
     public Long createUser(UserCreateRequest request){
         validateDuplicateUser(request.getName());
@@ -67,4 +74,15 @@ public class UserService {
   public boolean existsById(Long userId) {
     return userRepository.existsById(userId);
   }
+
+  public UserInfoResponse getUserInfo(Long userId){
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
+
+    List<Long> teamIds = userTeamRepository.findActiveTeamIdsByUserId(userId);
+    List<Long> matchIds = matchUserRepository.findMatchIdsByUserId(userId);
+    return UserMapper.userInfoResponse(user, teamIds, matchIds);
+  }
 }
+
+

--- a/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
+++ b/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
@@ -21,6 +21,7 @@ import com.matchday.matchdayserver.userteam.model.mapper.UserTeamMapper;
 import com.matchday.matchdayserver.userteam.repository.UserTeamRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @Service
@@ -71,18 +72,19 @@ public class UserService {
         }
     }
 
-  public boolean existsById(Long userId) {
-    return userRepository.existsById(userId);
-  }
+    public boolean existsById(Long userId) {
+      return userRepository.existsById(userId);
+    }
 
-  public UserInfoResponse getUserInfo(Long userId){
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
+    @Transactional(readOnly = true)
+    public UserInfoResponse getUserInfo(Long userId){
+      User user = userRepository.findById(userId)
+          .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
 
-    List<Long> teamIds = userTeamRepository.findActiveTeamIdsByUserId(userId);
-    List<Long> matchIds = matchUserRepository.findMatchIdsByUserId(userId);
-    return UserMapper.userInfoResponse(user, teamIds, matchIds);
-  }
+      List<Long> teamIds = userTeamRepository.findActiveTeamIdsByUserId(userId);
+      List<Long> matchIds = matchUserRepository.findMatchIdsByUserId(userId);
+      return UserMapper.userInfoResponse(user, teamIds, matchIds);
+    }
 }
 
 

--- a/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
@@ -2,10 +2,16 @@ package com.matchday.matchdayserver.userteam.repository;
 
 import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     boolean existsByUserIdAndTeamId(Long userId, Long teamId);
     List<UserTeam> findAllByTeamId(Long teamId);
+
+    //활동 중인 team 목록
+    @Query("SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId AND ut.isActive = true")
+    List<Long> findActiveTeamIdsByUserId(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## Related Issue

[MAT-142](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-142)

## Overview
User 정보 조회용 API입니다.
특정 유저 이름, 현재 활동 중인 소속팀 목록, 참여한 매치 목록 반환합니다.

## Screenshot
<img width="845" alt="스크린샷 2025-05-01 오전 9 30 21" src="https://github.com/user-attachments/assets/3f66a53e-dbbc-4b2d-8c29-03271e036dae" />






[MAT-142]: https://match-day.atlassian.net/browse/MAT-142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 사용자의 상세 정보를 조회할 수 있는 새로운 GET 엔드포인트(`/api/v1/users/{userId}`)가 추가되었습니다. 해당 엔드포인트를 통해 사용자 이름, 소속 팀 ID 목록, 참가한 경기 ID 목록을 확인할 수 있습니다.
    - 사용자가 참여한 경기 ID 목록과 활성화된 소속 팀 ID 목록을 함께 조회할 수 있는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->