### PR TITLE
[MAT-133] 매치 관련 데이터 전부 삭제 및 초기화

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventRestController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventRestController.java
@@ -18,7 +18,7 @@ public class MatchEventRestController {
 
   private final MatchEventDeleteService matchEventDeleteService;
 
-  @Operation(summary = "이벤트 전체 삭제" , description = "matchId 해당하는 matchEvent 전체삭제")
+  @Operation(summary = "이벤트 전체 삭제" , description = "matchId 해당하는 matchEvent 전체삭제 <br>삭제 후 \"/topic/match-delete-events\" 채널로 Websocket 메시지 전송합니다")
   @DeleteMapping("/{matchId}")
   public ApiResponse<Long> deleteAllEvents(@PathVariable Long matchId) {
     return ApiResponse.ok(matchEventDeleteService.deleteAllEvents(matchId));

--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventRestController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventRestController.java
@@ -1,0 +1,26 @@
+package com.matchday.matchdayserver.matchevent.controller;
+
+import com.matchday.matchdayserver.common.response.ApiResponse;
+import com.matchday.matchdayserver.matchevent.service.MatchEventDeleteService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "match-event", description = "매치 이벤트 관련 API")
+@RequestMapping("/api/v1/match-event")
+@RestController
+@RequiredArgsConstructor
+public class MatchEventRestController {
+
+  private final MatchEventDeleteService matchEventDeleteService;
+
+  @Operation(summary = "이벤트 전체 삭제" , description = "matchId 해당하는 matchEvent 전체삭제")
+  @DeleteMapping("/{matchId}")
+  public ApiResponse<Long> deleteAllEvents(@PathVariable Long matchId) {
+    return ApiResponse.ok(matchEventDeleteService.deleteAllEvents(matchId));
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventDeleteResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventDeleteResponse.java
@@ -1,0 +1,15 @@
+package com.matchday.matchdayserver.matchevent.model.dto;
+
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "경기 이벤트 삭제 완료 응답 DTO")
+public class MatchEventDeleteResponse {
+  @Schema(description = "이벤트들이 삭제된 경기의 ID", example = "1")
+  private Long id;
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
 
-public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> { }
+public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
+  void deleteByMatchId(Long matchId);
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventDeleteService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventDeleteService.java
@@ -24,7 +24,7 @@ public class MatchEventDeleteService {
     matchRepository.findById(matchId).orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
     matchEventRepository.deleteByMatchId(matchId);
     MatchEventDeleteResponse response= new MatchEventDeleteResponse(matchId);
-    simpMessagingTemplate.convertAndSend("/topic/matchevents", response);
+    simpMessagingTemplate.convertAndSend("/topic/match-delete-events", response);
     return matchId;
   }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventDeleteService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventDeleteService.java
@@ -1,0 +1,30 @@
+package com.matchday.matchdayserver.matchevent.service;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchStatus;
+import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventDeleteResponse;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
+import com.matchday.matchdayserver.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchEventDeleteService {
+
+  private final MatchEventRepository matchEventRepository;
+  private final SimpMessagingTemplate simpMessagingTemplate;
+  private final MatchRepository matchRepository;
+
+  @Transactional
+  public Long deleteAllEvents(Long matchId){
+    matchRepository.findById(matchId).orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
+    matchEventRepository.deleteByMatchId(matchId);
+    MatchEventDeleteResponse response= new MatchEventDeleteResponse(matchId);
+    simpMessagingTemplate.convertAndSend("/topic/matchevents", response);
+    return matchId;
+  }
+}


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-133

## Overview

- matchId 에 해당하는 모든 match_event를 삭제합니다
- http 요청 방식으로 구현하였습니다
- 잘못된 matchId 입력시 예외처리합니다
- 삭제할 이벤트가 없는 경우엔 따로 예외처리를 하진 않았습니다
- **삭제 실시간 반영을 위해 삭제 후 "/topic/match-delete-events" 채널로 response 를 발행합니다**

## Screenshot

![스웨거 200](https://github.com/user-attachments/assets/738fd4b6-22cd-4d66-a4f5-113ed09ff976)
![실패한 삭제](https://github.com/user-attachments/assets/daf8e120-ce14-4746-bb45-c46519caf45c)
![sql삭제전](https://github.com/user-attachments/assets/2d7d2148-ef59-49d1-a4cc-3b895c47dc58)
![sql 삭제후](https://github.com/user-attachments/assets/1ebf6d3b-d24a-4bee-b2f8-a8f6d9a1d461)







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 특정 경기의 모든 경기 이벤트를 삭제할 수 있는 API 엔드포인트가 추가되었습니다.
    - 경기 이벤트 삭제 완료 시, 해당 정보를 실시간으로 웹소켓을 통해 알림 받을 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->