### PR TITLE
[MAT-144] MatchUser 중복 등록 체크 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
@@ -1,7 +1,9 @@
 package com.matchday.matchdayserver.common.response;
 
 public enum MatchUserStatus implements StatusInterface {
-    NOTFOUND_MATCH(404, 7001, "존재하지 않는 매치입니다");
+    NOTFOUND_MATCH(404, 7001, "존재하지 않는 매치입니다"),
+    ALREADY_REGISTERED(400, 7002, "매치에 이미 등록된 유저입니다")
+    ;
 
     private final int httpStatusCode;
     private final int customStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/common/response/TeamStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/TeamStatus.java
@@ -3,7 +3,9 @@ package com.matchday.matchdayserver.common.response;
 public enum TeamStatus implements StatusInterface {
     DUPLICATE_TEAMNAME(400, 5001, "이미 존재하는 팀 이름"),
     NOTFOUND_TEAM(404,5002, "존재하지 않는 팀입니다"),
-    ALREADY_JOINED_USER(400,5003, "팀에 이미 유저가 소속되어있음");
+    ALREADY_JOINED_USER(400,5003, "팀에 이미 유저가 소속되어있음"),
+    INACTIVE_USER_TEAM(400, 5004, "현재 해당 팀에 활동 중이 아닌 사용자입니다")
+  ;
 
     private final int httpStatusCode;
     private final int customStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -13,4 +13,7 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
       "JOIN FETCH mu.user u " +
       "WHERE mu.match.id = :matchId AND mu.user.id = :userId")
   Optional<MatchUser> findByMatchIdAndUserIdWithFetch(@Param("matchId") Long matchId, @Param("userId") Long userId);
+
+  //특정 매치에 특정 유저가 존재하는지 여부
+  boolean existsByMatchIdAndUserId(Long matchId, Long userId);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -29,6 +29,11 @@ public class MatchUserService {
         User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
 
+        //중복 등록 여부 확인
+        if (matchUserRepository.existsByMatchIdAndUserId(matchId, request.getUserId())) {
+          throw new ApiException(MatchUserStatus.ALREADY_REGISTERED);
+        }
+
         MatchUser matchUser = MatchUserMapper.toMatchUser(match, user, request);
         matchUserRepository.save(matchUser);
     }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -2,6 +2,7 @@ package com.matchday.matchdayserver.matchuser.service;
 
 import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.MatchUserStatus;
+import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.common.response.UserStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
@@ -11,6 +12,8 @@ import com.matchday.matchdayserver.matchuser.model.mapper.MatchUserMapper;
 import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.repository.UserRepository;
+import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
+import com.matchday.matchdayserver.userteam.repository.UserTeamRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,6 +24,7 @@ public class MatchUserService {
     private final MatchUserRepository matchUserRepository;
     private final MatchRepository matchRepository;
     private final UserRepository userRepository;
+    private final UserTeamRepository userTeamRepository;
 
     @Transactional
     public void create(Long matchId, MatchUserCreateRequest request){
@@ -28,6 +32,12 @@ public class MatchUserService {
                 .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCH));
         User user = userRepository.findById(request.getUserId())
                 .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
+
+
+        //현재 해당 팀에서 활동 중인지 여부 확인
+        UserTeam userTeam = userTeamRepository.findActiveUserInHomeTeam(user.getId(), match.getId())
+            .orElseThrow(() -> new ApiException(TeamStatus.INACTIVE_USER_TEAM));
+
 
         //중복 등록 여부 확인
         if (matchUserRepository.existsByMatchIdAndUserId(matchId, request.getUserId())) {

--- a/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
@@ -2,10 +2,20 @@ package com.matchday.matchdayserver.userteam.repository;
 
 import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     boolean existsByUserIdAndTeamId(Long userId, Long teamId);
     List<UserTeam> findAllByTeamId(Long teamId);
+
+    @Query("""
+    SELECT ut FROM UserTeam ut
+    JOIN Match m ON m.homeTeam.id = ut.team.id
+    WHERE ut.user.id = :userId AND m.id = :matchId AND ut.isActive = true
+    """)
+    Optional<UserTeam> findActiveUserInHomeTeam(Long userId, Long matchId);
+
 }


### PR DESCRIPTION
## Related Issue

[MAT-144](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-144)

## Overview
1. 한 매치에 동일 유저 등록 불가하도록 예외처리 추가
2. 특정 유저가 해당 팀에서 비활성 상태(isActive = false)일 경우, 해당 팀의 매치 등록 불가하도록 예외처리 추가

## Screenshot

<img width="723" alt="스크린샷 2025-05-01 오후 4 23 02" src="https://github.com/user-attachments/assets/b0c5befa-951e-4d03-aea8-4e17be9b8805" />

<img width="734" alt="스크린샷 2025-05-01 오후 4 22 40" src="https://github.com/user-attachments/assets/2b0e8704-4b00-40e5-9ee9-ff33783f83cb" />





[MAT-144]: https://match-day.atlassian.net/browse/MAT-144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 매치에 이미 등록된 사용자를 감지하여 중복 등록 시 에러 메시지를 제공합니다.
    - 매치의 홈팀에 소속되어 있지 않거나 비활성화된 사용자가 등록을 시도할 경우 에러 메시지를 제공합니다.

- **버그 수정**
    - 중복 등록 및 팀 소속 상태에 대한 검증이 강화되어 잘못된 등록을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->