### PR TITLE
[MAT-101] 매치 이벤트 조회 API 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -25,9 +25,9 @@ public class MatchController {
 
     @Operation(summary = "매치 생성")
     @PostMapping
-    public ApiResponse<String> createMatch(@RequestBody MatchCreateRequest request) {
-        matchCreateService.create(request);
-        return ApiResponse.ok("매치 생성 완료");
+    public ApiResponse<Long> createMatch(@RequestBody MatchCreateRequest request) {
+        Long id = matchCreateService.create(request);
+        return ApiResponse.ok(id);
     }
 
     @GetMapping("/{matchId}")

--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventHistoryController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventHistoryController.java
@@ -1,0 +1,28 @@
+package com.matchday.matchdayserver.matchevent.controller;
+
+import com.matchday.matchdayserver.common.response.ApiResponse;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
+import com.matchday.matchdayserver.matchevent.service.MatchEventHistoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@Tag(name = "matches", description = "매치 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/matches")
+public class MatchEventHistoryController {
+
+  private final MatchEventHistoryService matchEventHistoryService;
+
+  @GetMapping("/{matchId}/history")
+  @Operation(summary = "매치 이벤트 이력 조회")
+  public ApiResponse<List<MatchEventResponse>> getMatchEventHistory(@PathVariable Long matchId) {
+    return ApiResponse.ok(matchEventHistoryService.findAllHistoryByMatchId(matchId));
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventWebSocketController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventWebSocketController.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 
 @Controller
 @RequiredArgsConstructor
-public class MatchEventController {
+public class MatchEventWebSocketController {
 
   private final MatchEventSaveService matchEventSaveService;
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
@@ -3,6 +3,7 @@ package com.matchday.matchdayserver.matchevent.mapper;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.user.model.entity.User;
@@ -12,20 +13,21 @@ import java.time.LocalDateTime;
 
 public class MatchEventMapper {
 
-  public static MatchEvent toEntity(MatchEventRequest request, Match match, User user) {
+  public static MatchEvent toEntity(MatchEventRequest request, Match match, MatchUser matchUser) {
     return MatchEvent.builder()
         .eventType(request.getEventType())
         .description(request.getDescription())
         .match(match)
-        .user(user)
+        .matchUser(matchUser)
         .build();
   }
 
-  public static MatchEventResponse toResponse(MatchEvent matchEvent, Team team) {
+  public static MatchEventResponse toResponse(MatchEvent matchEvent) {
     Match match = matchEvent.getMatch();
-    User user = matchEvent.getUser();
     Long elapsedMinutes = calculateElapsedMinutes(match.getStartTime().atDate(match.getMatchDate()),
         matchEvent.getEventTime());
+    User user = matchEvent.getMatchUser().getUser();
+    Team team = matchEvent.getMatchUser().getTeam();
 
     return MatchEventResponse.builder()
         .id(matchEvent.getId())

--- a/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
@@ -34,7 +34,7 @@ public class MatchEventMapper {
         .teamName(team.getName())
         .userId(user.getId())
         .userName(user.getName())
-        .eventLog(matchEvent.getEventType().value)
+        .eventLog(matchEvent.getEventType().name())
         .build();
   }
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/entity/MatchEvent.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/entity/MatchEvent.java
@@ -2,7 +2,7 @@ package com.matchday.matchdayserver.matchevent.model.entity;
 
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
-import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -43,15 +43,15 @@ public class MatchEvent {
     private Match match;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "match_user_id", nullable = false)
+    private MatchUser matchUser;
 
     public MatchEvent copyWith(MatchEventType eventType) {
         return MatchEvent.builder()
                 .eventType(eventType)
                 .description(this.description)
                 .match(this.match)
-                .user(this.user)
+                .matchUser(this.matchUser)
                 .build();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -3,5 +3,17 @@ package com.matchday.matchdayserver.matchevent.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import java.util.List;
 
-public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> { }
+public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
+
+  @Query("""
+          select me from MatchEvent me
+          join fetch me.matchUser as mu
+          join fetch me.match as m
+          where m.id = :id
+      """)
+  List<MatchEvent> findByMatchIdFetchMatchUserAndMatch(@Param("id") Long matchId);
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventHistoryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventHistoryService.java
@@ -1,0 +1,24 @@
+package com.matchday.matchdayserver.matchevent.service;
+
+import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MatchEventHistoryService {
+
+  private final MatchEventRepository matchEventRepository;
+
+  public List<MatchEventResponse> findAllHistoryByMatchId(Long matchId) {
+    return matchEventRepository.findByMatchIdFetchMatchUserAndMatch(matchId)
+        .stream()
+        .map(MatchEventMapper::toResponse)
+        .toList();
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -46,11 +46,10 @@ public class MatchEventSaveService {
         .findByMatchIdAndUserIdWithFetch(matchId, request.getData().getUserId())
         .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
 
-    User user = matchUser.getUser();
     Match match = matchUser.getMatch();
 
     List<MatchEventResponse> matchEventResponse = matchEventStrategy
-        .generateMatchEventLog(request.getData(), match, user);
+        .generateMatchEventLog(request.getData(), match, matchUser);
     for (MatchEventResponse response : matchEventResponse) {
       messagingTemplate.convertAndSend("/topic/match/" + matchId, response);
     }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
@@ -6,8 +6,6 @@ import java.util.List;
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
 import org.springframework.stereotype.Component;
 
-import com.matchday.matchdayserver.common.exception.ApiException;
-import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
@@ -15,9 +13,7 @@ import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
 import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
 import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
-import com.matchday.matchdayserver.team.model.entity.Team;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
-import com.matchday.matchdayserver.user.model.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -38,7 +34,6 @@ import lombok.RequiredArgsConstructor;
 public class MatchEventStrategy {
 
   private final MatchEventRepository matchEventRepository;
-  private final TeamRepository teamRepository;
 
   public List<MatchEventResponse> generateMatchEventLog(MatchEventRequest request, Match match, MatchUser matchUser) {
     return generateMatchEvent(request, match, matchUser);

--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
@@ -17,9 +17,9 @@ public class MatchUserController {
 
     @Operation(summary = "매치 유저 등록", description = "{matchID}에 사용자(user)가 등록됩니다.")
     @PostMapping("/{matchId}/users")
-    public ApiResponse<String> createMatch(@PathVariable Long matchId,
+    public ApiResponse<Long> createMatch(@PathVariable Long matchId,
                                            @RequestBody MatchUserCreateRequest request) {
-        matchPlayerService.create(matchId, request);
-        return ApiResponse.ok("매치 유저 등록 완료");
+        Long id = matchPlayerService.create(matchId, request);
+        return ApiResponse.ok(id);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -1,6 +1,7 @@
 package com.matchday.matchdayserver.matchuser.model.entity;
 
 import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
 import com.matchday.matchdayserver.matchuser.model.enums.MatchUserRole;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import com.matchday.matchdayserver.user.model.entity.User;
@@ -10,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.util.List;
 
 @Entity
 @Getter
@@ -30,7 +32,7 @@ public class MatchUser {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id", nullable = false)
+    @JoinColumn(name = "team_id")
     private Team team;
 
     @Enumerated(EnumType.STRING)
@@ -42,4 +44,7 @@ public class MatchUser {
 
     @Column(name = "match_grid") // 감독 고려하여 null 허용
     private String matchGrid;
+
+    @OneToMany(mappedBy = "matchUser", cascade = CascadeType.REMOVE)
+    private List<MatchEvent> matchEvents;
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -9,6 +9,7 @@ import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.matchuser.model.enums.MatchUserRole;
 import com.matchday.matchdayserver.matchuser.model.mapper.MatchUserMapper;
 import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
 import com.matchday.matchdayserver.team.model.entity.Team;
@@ -23,32 +24,60 @@ import java.util.Objects;
 @Service
 @RequiredArgsConstructor
 public class MatchUserService {
-    private final MatchUserRepository matchUserRepository;
-    private final MatchRepository matchRepository;
-    private final UserRepository userRepository;
-    private final TeamRepository teamRepository;
 
-    @Transactional
-    public Long create(Long matchId, MatchUserCreateRequest request) {
-        Match match = matchRepository.findById(matchId)
-                .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCH));
-        User user = userRepository.findById(request.getUserId())
-                .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
-        Team team = teamRepository.findByTeamIdAndUserId(request.getTeamId(), request.getTeamId())
-                .orElseThrow(() -> new ApiException(TeamStatus.NOTFOUND_TEAM));
+  private final MatchUserRepository matchUserRepository;
+  private final MatchRepository matchRepository;
+  private final UserRepository userRepository;
+  private final TeamRepository teamRepository;
 
-        if (!Objects.equals(match.getHomeTeam().getId(), team.getId()) &&
-            !Objects.equals(match.getAwayTeam().getId(), team.getId())) {
-            throw new ApiException(MatchStatus.NOTFOUND_MATCH);
-        }
+  @Transactional
+  public Long create(Long matchId, MatchUserCreateRequest request) {
+    Match match = matchRepository.findById(matchId)
+        .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCH));
+    User user = userRepository.findById(request.getUserId())
+        .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
 
-        //중복 등록 여부 확인
-        if (matchUserRepository.existsByMatchIdAndUserId(matchId, request.getUserId())) {
-          throw new ApiException(MatchUserStatus.ALREADY_REGISTERED);
-        }
+    Team team = null;
 
-        MatchUser matchUser = MatchUserMapper.toMatchUser(match, user, team, request);
-        matchUserRepository.save(matchUser);
-        return matchUser.getId();
+    if (!canIgnoreTeamConstraints(request.getRole())) {
+      team = teamRepository.findById(request.getTeamId())
+          .orElseThrow(() -> new ApiException(TeamStatus.NOTFOUND_TEAM));
     }
+
+    if (isTeamNotInMatch(team, match)) {
+      throw new ApiException(MatchStatus.NOTFOUND_MATCH);
+    }
+    //중복 등록 여부 확인
+    if (matchUserRepository.existsByMatchIdAndUserId(matchId, request.getUserId())) {
+      throw new ApiException(MatchUserStatus.ALREADY_REGISTERED);
+    }
+
+    MatchUser matchUser = MatchUserMapper.toMatchUser(match, user, team, request);
+    matchUserRepository.save(matchUser);
+    return matchUser.getId();
+  }
+
+  /**
+   * 팀이 매치에 포함되어 있지 않은지 확인하는 메서드
+   *
+   * @param team
+   * @param match
+   * @return true: 팀이 매치에 포함되어 있지 않음, false: 팀이 매치에 포함되어 있음
+   */
+  private static boolean isTeamNotInMatch(Team team, Match match) {
+    if (team == null) {
+      return false; // 팀이 null이면 조건 검사를 하지 않음
+    }
+
+    boolean isHomeTeam = match.getHomeTeam() != null &&
+        Objects.equals(match.getHomeTeam().getId(), team.getId());
+    boolean isAwayTeam = match.getAwayTeam() != null &&
+        Objects.equals(match.getAwayTeam().getId(), team.getId());
+
+    return !isHomeTeam && !isAwayTeam;
+  }
+
+  private boolean canIgnoreTeamConstraints(MatchUserRole matchUserRole) {
+    return matchUserRole == MatchUserRole.ADMIN || matchUserRole == MatchUserRole.ARCHIVES;
+  }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -29,7 +29,7 @@ public class MatchUserService {
     private final TeamRepository teamRepository;
 
     @Transactional
-    public void create(Long matchId, MatchUserCreateRequest request){
+    public Long create(Long matchId, MatchUserCreateRequest request) {
         Match match = matchRepository.findById(matchId)
                 .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCH));
         User user = userRepository.findById(request.getUserId())
@@ -49,5 +49,6 @@ public class MatchUserService {
 
         MatchUser matchUser = MatchUserMapper.toMatchUser(match, user, team, request);
         matchUserRepository.save(matchUser);
+        return matchUser.getId();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/team/repository/TeamRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/team/repository/TeamRepository.java
@@ -6,32 +6,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
-    boolean existsByName(String name);
 
-    // ngram 기반 검색
-    @Query(value = "SELECT * FROM team WHERE MATCH(name) AGAINST(:keyword IN NATURAL LANGUAGE MODE)", nativeQuery = true)
-    List<Team> searchByKeyword(@Param("keyword") String keyword);
+  boolean existsByName(String name);
 
-    @Query("""
-                SELECT t FROM Team t
-                WHERE (t.id = (SELECT m.homeTeam.id FROM Match m WHERE m.id = :matchId)
-                OR t.id = (SELECT m.awayTeam.id FROM Match m WHERE m.id = :matchId))
-                AND t.id = (SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId)
-            """)
-    Optional<Team> findByMatchIdAndUserId(@Param("matchId") Long matchId, @Param("userId") Long userId);
-
-    @Query("""
-            SELECT t FROM Team t
-            WHERE t.id = :teamId
-            AND EXISTS (
-                SELECT 1 FROM UserTeam ut
-                WHERE ut.team.id = t.id
-                AND ut.user.id = :userId
-                AND ut.isActive = true
-            )
-            """)
-    Optional<Team> findByTeamIdAndUserId(@Param("teamId") Long teamId, @Param("userId") Long userId);
+  // ngram 기반 검색
+  @Query(value = "SELECT * FROM team WHERE MATCH(name) AGAINST(:keyword IN NATURAL LANGUAGE MODE)", nativeQuery = true)
+  List<Team> searchByKeyword(@Param("keyword") String keyword);
 }

--- a/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
@@ -17,7 +17,7 @@
         @GeneratedValue(strategy = GenerationType.IDENTITY)
         private Long id;
 
-        @Column(nullable = false, length = 30, unique = true)
+        @Column(nullable = false, length = 30)
         private String name;
 
         @Builder
@@ -31,7 +31,4 @@
 
         @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
         private List<UserTeam> userTeams;
-
-        @OneToMany(mappedBy = "user") // cascade = CascadeType.REMOVE 안한 이유 : 유저의 과거 기록은 남겨두는게 좋을듯?
-        private List<MatchEvent> matchEvents;
     }


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-101

## Overview

- MatchEvent <-> User 연관 삭제
- MatchEvent <-> MatchUser 연관 추가
- MatchEvent 조회 API 구현
- EventType 한글로 표기 -> 영문 표기로 변경

## Review Request 

- 연관관계 변경에 따른 사이드 이펙트가 없을지 점검이 필요합니다.

## Screenshot

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/9839e632-9a04-4e69-be45-3b0054c577a0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 특정 매치의 이벤트 이력을 조회할 수 있는 API가 추가되었습니다.

- **기능 개선**
    - 매치 생성 및 매치 유저 등록 시, 성공 메시지 대신 생성된 ID를 반환하도록 응답이 개선되었습니다.
    - 매치 이벤트 관련 API 및 내부 로직이 MatchUser 기반으로 일원화되어, 사용자와 팀 정보 처리가 간소화되었습니다.
    - 매치 유저 등록 시 사용자 역할에 따라 팀 검증이 유연하게 처리되도록 개선되었습니다.

- **버그 수정**
    - 사용자 이름의 중복 제한이 해제되어 동일한 이름을 가진 사용자가 여러 명 등록될 수 있습니다.

- **기타**
    - 일부 불필요한 팀 관련 조회 기능이 제거되었습니다.
    - 매치 유저와 매치 이벤트 간의 연관관계가 추가되어, 매치 유저 삭제 시 관련 이벤트도 함께 삭제됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->