### PR TITLE
[MAT-150] MatchScore 조회 API 구현

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 [*]
 charset = utf-8
 end_of_line = lf
-indent_size = 2
+indent_size = 4
 indent_style = space
 insert_final_newline = false
 max_line_length = 100

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  mysql:
+    image: mysql:latest
+    container_name: matchday_mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: matchday_schema
+    ports:
+      - "3306:3306"
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+
+volumes:
+  mysql_data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,3 @@ services:
     command:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
-
-volumes:
-  mysql_data:

--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -4,8 +4,10 @@ import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.match.model.dto.request.MatchCreateRequest;
 import com.matchday.matchdayserver.match.model.dto.request.MatchMemoRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchMemoResponse;
 import com.matchday.matchdayserver.match.service.MatchCreateService;
+import com.matchday.matchdayserver.match.service.MatchScoreService;
 import com.matchday.matchdayserver.match.service.MatchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MatchController {
     private final MatchCreateService matchCreateService;
     private final MatchService matchService;
+    private final MatchScoreService matchScoreService;
 
     @Operation(summary = "매치 생성")
     @PostMapping
@@ -36,8 +39,15 @@ public class MatchController {
     @GetMapping("/{matchId}")
     @Operation(summary = "매치 정보 조회")
     public ApiResponse<MatchInfoResponse> getMatchInfo(@PathVariable Long matchId) {
-      MatchInfoResponse response = matchService.getMatchInfo(matchId);
-      return ApiResponse.ok(response);
+        MatchInfoResponse response = matchService.getMatchInfo(matchId);
+        return ApiResponse.ok(response);
+    }
+
+    @GetMapping("/{matchId}/score")
+    @Operation(summary = "매치 점수 조회")
+    public ApiResponse<MatchScoreResponse> getMatchScore(@PathVariable Long matchId) {
+        MatchScoreResponse response = matchScoreService.getMatchScore(matchId);
+        return ApiResponse.ok(response);
     }
 
     @Operation(summary = "매치 팀 메모 등록/수정", description = "특정 경기의 특정 팀에 대한 메모를 생성하거나 수정합니다 null 값 입력시 메모 초기화.")

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
@@ -1,0 +1,54 @@
+package com.matchday.matchdayserver.match.model.dto.response;
+
+import com.matchday.matchdayserver.matchevent.model.dto.ScoreResponse;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+
+@Getter
+@Schema(description = "경기 점수 응답 객체")
+public class MatchScoreResponse {
+
+    @Schema(description = "경기 ID", example = "1")
+    private long matchId;
+    @Schema(description = "홈팀 ID", example = "1")
+    private long homeTeamId;
+    @Schema(description = "상대팀 ID", example = "2")
+    private long awayTeamId;
+    @Schema(description = "홈팀 점수")
+    private ScoreResponse homeScore;
+    @Schema(description = "상대팀 점수")
+    private ScoreResponse awayScore;
+
+    @Builder
+    public MatchScoreResponse(long matchId, long homeTeamId, long awayTeamId) {
+        this.homeTeamId = homeTeamId;
+        this.awayTeamId = awayTeamId;
+        this.matchId = matchId;
+        this.homeScore = ScoreResponse.defaultScore();
+        this.awayScore = ScoreResponse.defaultScore();
+    }
+
+    public void updateScore(Long teamId, MatchEventType eventType) {
+        if (teamId.equals(this.homeTeamId)) {
+            updateScore(homeScore, eventType);
+        } else if (teamId.equals(this.awayTeamId)) {
+            updateScore(awayScore, eventType);
+        }
+    }
+
+    private void updateScore(ScoreResponse score, MatchEventType eventType) {
+        switch (eventType) {
+            case GOAL -> score.upGoalCount();
+            case SHOT -> score.upShotCount();
+            case VALID_SHOT -> score.upValidShotCount();
+            case CORNER_KICK -> score.upCornerKickCount();
+            case FOUL -> score.upFoulCount();
+            case OFFSIDE -> score.upOffsideCount();
+            case YELLOW_CARD -> score.upWarningCount();
+            case RED_CARD -> score.upWarningCount();
+        }
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
@@ -1,5 +1,7 @@
 package com.matchday.matchdayserver.match.model.dto.response;
 
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchStatus;
 import com.matchday.matchdayserver.matchevent.model.dto.ScoreResponse;
 import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -36,6 +38,8 @@ public class MatchScoreResponse {
             updateScore(homeScore, eventType);
         } else if (teamId.equals(this.awayTeamId)) {
             updateScore(awayScore, eventType);
+        } else {
+            throw new ApiException(MatchStatus.NOTFOUND_TEAM);
         }
     }
 

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchScoreService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchScoreService.java
@@ -1,0 +1,40 @@
+package com.matchday.matchdayserver.match.service;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchStatus;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
+import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MatchScoreService {
+
+  private final MatchEventRepository matchEventRepository;
+  private final MatchRepository matchRepository;
+
+
+  public MatchScoreResponse getMatchScore(Long matchId) {
+    Match match = matchRepository.findById(matchId)
+        .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
+    MatchScoreResponse matchScoreResponse = MatchScoreResponse.builder()
+        .homeTeamId(match.getHomeTeam().getId())
+        .awayTeamId(match.getAwayTeam().getId())
+        .matchId(match.getId())
+        .build();
+    List<MatchEvent> matchEvents = matchEventRepository.findByMatchId(matchId);
+
+    for(MatchEvent matchEvent : matchEvents) {
+      long teamId = matchEvent.getMatchUser().getTeam().getId();
+      matchScoreResponse.updateScore(teamId, matchEvent.getEventType());
+    }
+    return matchScoreResponse;
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventHistoryController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventHistoryController.java
@@ -18,11 +18,11 @@ import java.util.List;
 @RequestMapping("/api/v1/matches")
 public class MatchEventHistoryController {
 
-    private final MatchEventHistoryService matchService;
+    private final MatchEventHistoryService matchEventHistoryService;
 
     @GetMapping("/{matchId}/history")
     @Operation(summary = "매치 이벤트 이력 조회")
     public ApiResponse<List<MatchEventResponse>> getMatchEventHistory(@PathVariable Long matchId) {
-        return ApiResponse.ok(matchService.findAllHistoryByMatchId(matchId));
+        return ApiResponse.ok(matchEventHistoryService.findAllHistoryByMatchId(matchId));
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventHistoryController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventHistoryController.java
@@ -18,11 +18,11 @@ import java.util.List;
 @RequestMapping("/api/v1/matches")
 public class MatchEventHistoryController {
 
-  private final MatchEventHistoryService matchEventHistoryService;
+    private final MatchEventHistoryService matchService;
 
-  @GetMapping("/{matchId}/history")
-  @Operation(summary = "매치 이벤트 이력 조회")
-  public ApiResponse<List<MatchEventResponse>> getMatchEventHistory(@PathVariable Long matchId) {
-    return ApiResponse.ok(matchEventHistoryService.findAllHistoryByMatchId(matchId));
-  }
+    @GetMapping("/{matchId}/history")
+    @Operation(summary = "매치 이벤트 이력 조회")
+    public ApiResponse<List<MatchEventResponse>> getMatchEventHistory(@PathVariable Long matchId) {
+        return ApiResponse.ok(matchService.findAllHistoryByMatchId(matchId));
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/ScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/ScoreResponse.java
@@ -1,0 +1,77 @@
+package com.matchday.matchdayserver.matchevent.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "경기 중 다양한 이벤트 발생 횟수 응답 객체")
+public class ScoreResponse {
+
+  @Schema(description = "골 횟수", example = "3")
+  private int goalCount;
+
+  @Schema(description = "슈팅 횟수", example = "10")
+  private int shotCount;
+
+  @Schema(description = "유효 슈팅 횟수", example = "5")
+  private int validShotCount;
+
+  @Schema(description = "코너킥 횟수", example = "7")
+  private int cornerKickCount;
+
+  @Schema(description = "오프사이드 횟수", example = "3")
+  private int offsideCount;
+
+  @Schema(description = "파울 횟수", example = "15")
+  private int foulCount;
+
+  @Schema(description = "경고 횟수", example = "2")
+  private int warningCount;
+
+  public void upGoalCount() {
+    this.goalCount++;
+  }
+
+  public void upShotCount() {
+    this.shotCount++;
+  }
+
+  public void upValidShotCount() {
+    this.validShotCount++;
+  }
+
+  public void upCornerKickCount() {
+    this.cornerKickCount++;
+  }
+
+  public void upOffsideCount() {
+    this.offsideCount++;
+  }
+
+  public void upFoulCount() {
+    this.foulCount++;
+  }
+
+  public void upWarningCount() {
+    this.warningCount++;
+  }
+
+  public static ScoreResponse defaultScore() {
+    return ScoreResponse.builder()
+        .goalCount(0)
+        .shotCount(0)
+        .validShotCount(0)
+        .cornerKickCount(0)
+        .offsideCount(0)
+        .foulCount(0)
+        .warningCount(0)
+        .build();
+  }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/enums/MatchEventType.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/enums/MatchEventType.java
@@ -13,6 +13,9 @@ public enum MatchEventType {
     @Schema(description = "슛")
     SHOT("슛"),
 
+    @Schema(description = "코너킥")
+    CORNER_KICK("코너킥"),
+
     @Schema(description = "유효슛")
     VALID_SHOT("유효슛"),
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -9,11 +9,13 @@ import java.util.List;
 
 public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
 
-  @Query("""
-          select me from MatchEvent me
-          join fetch me.matchUser as mu
-          join fetch me.match as m
-          where m.id = :id
-      """)
-  List<MatchEvent> findByMatchIdFetchMatchUserAndMatch(@Param("id") Long matchId);
+    @Query("""
+            select me from MatchEvent me
+            join fetch me.matchUser as mu
+            join fetch me.match as m
+            where m.id = :id
+        """)
+    List<MatchEvent> findByMatchIdFetchMatchUserAndMatch(@Param("id") Long matchId);
+
+    List<MatchEvent> findByMatchId(Long matchId);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventHistoryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventHistoryService.java
@@ -1,6 +1,5 @@
 package com.matchday.matchdayserver.matchevent.service;
 
-import com.matchday.matchdayserver.match.repository.MatchRepository;
 import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
 import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
@@ -15,7 +14,6 @@ import java.util.List;
 public class MatchEventHistoryService {
 
     private final MatchEventRepository matchEventRepository;
-    private final MatchRepository matchRepository;
 
     public List<MatchEventResponse> findAllHistoryByMatchId(Long matchId) {
         return matchEventRepository.findByMatchIdFetchMatchUserAndMatch(matchId)

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventHistoryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventHistoryService.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.matchevent.service;
 
+import com.matchday.matchdayserver.match.repository.MatchRepository;
 import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
 import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
@@ -13,12 +14,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MatchEventHistoryService {
 
-  private final MatchEventRepository matchEventRepository;
+    private final MatchEventRepository matchEventRepository;
+    private final MatchRepository matchRepository;
 
-  public List<MatchEventResponse> findAllHistoryByMatchId(Long matchId) {
-    return matchEventRepository.findByMatchIdFetchMatchUserAndMatch(matchId)
-        .stream()
-        .map(MatchEventMapper::toResponse)
-        .toList();
-  }
+    public List<MatchEventResponse> findAllHistoryByMatchId(Long matchId) {
+        return matchEventRepository.findByMatchIdFetchMatchUserAndMatch(matchId)
+            .stream()
+            .map(MatchEventMapper::toResponse)
+            .toList();
+    }
 }


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-150

## Overview

- match 조
- .editorconfig ident 4로 수정
- 로컬 개발용 mysql docker compose 구현

## Screenshot

<img width="1480" alt="image" src="https://github.com/user-attachments/assets/a500c039-8df1-4e8d-8b01-4093d4d57917" />







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 경기 점수 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  - 경기 점수 및 각종 경기 이벤트(골, 슛, 유효슛, 코너킥 등)를 나타내는 응답 객체가 도입되었습니다.
  - 코너킥이 경기 이벤트 유형에 새롭게 추가되었습니다.

- **환경설정**
  - MySQL 데이터베이스 구성을 위한 docker-compose 파일이 추가되었습니다.
  - 전체 코드의 들여쓰기가 2칸에서 4칸으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->