### PR TITLE
[MAT-132] 선수 교체 WebSocket Endpoint 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
@@ -13,6 +13,7 @@ public enum MatchStatus implements StatusInterface {
     SOCKET_ERROR(500, 6010, "웹소켓 오류"),
     TEAM_NOT_PARTICIPATING(400, 6011, "해당 팀은 입력받은 경기의 홈팀도, 어웨이팀도 아닙니다."),
     MEMO_NOT_FOUND(404, 6012, "존재하지 않는 매모 입니다"),
+    DIFFERENT_TEAM_EXCHANGE(400, 6013, "서로 다른 팀의 선수는 교체할 수 없습니다")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserExchangeController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserExchangeController.java
@@ -1,0 +1,22 @@
+package com.matchday.matchdayserver.matchuser.controller;
+
+import com.matchday.matchdayserver.common.model.Message;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserExchangeRequest;
+import com.matchday.matchdayserver.matchuser.service.MatchUserExchangeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MatchUserExchangeController {
+
+    private final MatchUserExchangeService matchUserExchangeService;
+
+    @MessageMapping("/match/{matchId}/exchange")
+    public void exchangePlayer(@DestinationVariable Long matchId,
+        Message<MatchUserExchangeRequest> matchUserExchangeRequest) {
+        matchUserExchangeService.exchangeMatchUser(matchId, matchUserExchangeRequest);
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserExchangeRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserExchangeRequest.java
@@ -13,7 +13,7 @@ public class MatchUserExchangeRequest {
   @Schema(description = "교체할 선수의 매치 유저 아이디")
   private Long fromMatchUserId;
   @Schema(description = "교체할 선수의 유저 아이디")
-  private Long toUserId;
+  private Long toMatchUserId;
   @Schema(description = "교체 사유 등")
   private String message;
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserExchangeRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserExchangeRequest.java
@@ -1,0 +1,19 @@
+package com.matchday.matchdayserver.matchuser.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchUserExchangeRequest {
+  @Schema(description = "교체할 선수의 매치 유저 아이디")
+  private Long fromMatchUserId;
+  @Schema(description = "교체할 선수의 유저 아이디")
+  private Long toUserId;
+  @Schema(description = "교체 사유 등")
+  private String message;
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -62,10 +62,12 @@ public class MatchUser {
         if (!toMatchUser.getTeam().getId().equals(this.team.getId())) {
             throw new ApiException(MatchStatus.DIFFERENT_TEAM_EXCHANGE);
         }
+        String originalPosition = toMatchUser.getMatchPosition();
+        String originalGrid = toMatchUser.getMatchGrid();
         toMatchUser.updateMatchPosition(this.matchPosition);
         toMatchUser.updateMatchGrid(this.matchGrid);
 
-        this.matchPosition = null;
-        this.matchGrid = null;
+        this.matchPosition = originalPosition;
+        this.matchGrid = originalGrid;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -1,5 +1,7 @@
 package com.matchday.matchdayserver.matchuser.model.entity;
 
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
 import com.matchday.matchdayserver.matchuser.model.enums.MatchUserRole;
@@ -47,4 +49,23 @@ public class MatchUser {
 
     @OneToMany(mappedBy = "matchUser", cascade = CascadeType.REMOVE)
     private List<MatchEvent> matchEvents;
+
+    public void updateMatchPosition(String matchPosition) {
+        this.matchPosition = matchPosition;
+    }
+
+    public void updateMatchGrid(String matchGrid) {
+        this.matchGrid = matchGrid;
+    }
+
+    public void exchange(MatchUser toMatchUser) {
+        if (!toMatchUser.getTeam().getId().equals(this.team.getId())) {
+            throw new ApiException(MatchStatus.DIFFERENT_TEAM_EXCHANGE);
+        }
+        toMatchUser.updateMatchPosition(this.matchPosition);
+        toMatchUser.updateMatchGrid(this.matchGrid);
+
+        this.matchPosition = null;
+        this.matchGrid = null;
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
@@ -42,7 +42,7 @@ public class MatchUserExchangeService {
             .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
 
         MatchUser toMatchUser = matchUserRepository
-            .findByMatchIdAndUserIdWithFetch(matchId, request.getData().getToUserId())
+            .findByMatchIdAndUserIdWithFetch(matchId, request.getData().getToMatchUserId())
             .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
 
         // Dirty Checking으로 자동 저장
@@ -93,7 +93,7 @@ public class MatchUserExchangeService {
         }
 
         if (request.getData().getFromMatchUserId() == null
-            || request.getData().getToUserId() == null) {
+            || request.getData().getToMatchUserId() == null) {
             errorMessages.add("fromMatchUserId, toUserId는 필수 입력 값입니다.");
         }
 

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
@@ -1,0 +1,106 @@
+package com.matchday.matchdayserver.matchuser.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.matchday.matchdayserver.common.response.DefaultStatus;
+import com.matchday.matchdayserver.common.response.UserStatus;
+import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
+import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.model.Message;
+import com.matchday.matchdayserver.common.response.MatchStatus;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserExchangeRequest;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MatchUserExchangeService {
+
+    private final MatchUserRepository matchUserRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+    private final MatchEventRepository matchEventRepository;
+
+    public void exchangeMatchUser(Long matchId, Message<MatchUserExchangeRequest> request) {
+        validateRequest(request);
+        validateAuthUser(matchId, request.getToken());
+
+        MatchUser fromMatchUser = matchUserRepository.findById(
+                request.getData().getFromMatchUserId())
+            .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
+
+        MatchUser toMatchUser = matchUserRepository
+            .findByMatchIdAndUserIdWithFetch(matchId, request.getData().getToUserId())
+            .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
+
+        // Dirty Checking으로 자동 저장
+        fromMatchUser.exchange(toMatchUser);
+
+        List<MatchEvent> matchEvents = List.of(
+            MatchEvent.builder()
+                .eventTime(LocalDateTime.now())
+                .eventType(MatchEventType.SUB_IN)
+                .description(request.getData().getMessage())
+                .match(toMatchUser.getMatch())
+                .matchUser(toMatchUser)
+                .build(),
+            MatchEvent.builder()
+                .eventTime(LocalDateTime.now())
+                .eventType(MatchEventType.SUB_OUT)
+                .description(request.getData().getMessage())
+                .match(toMatchUser.getMatch())
+                .matchUser(fromMatchUser)
+                .build());
+        matchEventRepository.saveAll(matchEvents);
+
+        List<MatchEventResponse> matchEventResponses = matchEvents.stream()
+            .map(MatchEventMapper::toResponse)
+            .toList();
+
+        for (MatchEventResponse response : matchEventResponses) {
+            messagingTemplate.convertAndSend("/topic/match/" + matchId, response);
+        }
+    }
+
+    private void validateAuthUser(Long matchId, String token) {
+        Long authId = Long.parseLong(token);
+
+        MatchUser authUser = matchUserRepository
+            .findByMatchIdAndUserIdWithFetch(matchId, authId)
+            .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
+
+        if (!authUser.getMatch().getId().equals(matchId)) {
+            throw new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER);
+        }
+    }
+
+    private void validateRequest(Message<MatchUserExchangeRequest> request) {
+        List<String> errorMessages = new ArrayList<>();
+        if (request.getToken() == null) {
+            errorMessages.add("token은 필수 입력 값입니다.");
+        }
+
+        if (request.getData().getFromMatchUserId() == null
+            || request.getData().getToUserId() == null) {
+            errorMessages.add("fromMatchUserId, toUserId는 필수 입력 값입니다.");
+        }
+
+        if (!errorMessages.isEmpty()) {
+            DefaultStatus defaultStatus = DefaultStatus.BAD_REQUEST;
+            defaultStatus.setCustomDescription(String.join("\n", errorMessages));
+            throw new ApiException(defaultStatus);
+        }
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
@@ -37,8 +37,8 @@ public class MatchUserExchangeService {
         validateRequest(request);
         validateAuthUser(matchId, request.getToken());
 
-        MatchUser fromMatchUser = matchUserRepository.findById(
-                request.getData().getFromMatchUserId())
+        MatchUser fromMatchUser = matchUserRepository
+            .findByMatchIdAndUserIdWithFetch(matchId, request.getData().getFromMatchUserId())
             .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
 
         MatchUser toMatchUser = matchUserRepository


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-132

## Overview 

- PoC는 여기서 확인해주시면 감사하겠습니다.
- https://github.com/matchday-team/poc/tree/main/web-socket-poc 

## Screenshot

<img src="https://github.com/user-attachments/assets/068959ec-8b1d-4bf5-92de-a87eaf2c45b4" width="50%" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 경기 중 선수 교체(교환) 기능이 추가되었습니다. 이제 실시간으로 선수 교체 요청을 할 수 있으며, 교체 시 관련 이벤트가 즉시 반영되어 모든 참가자에게 안내됩니다.
- **버그 수정**
    - 서로 다른 팀 선수 간의 교체 시도 시, 안내 메시지와 함께 교체가 제한됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->