### PR TITLE
[MAT-136] 팀 별 경기 출전하는 선수 명단 조회 api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ out/
 # 민감정보
 .env
 .DS_Store
+**/application_dev.yml
+**/spy.properties

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //p6spy
+    implementation 'p6spy:p6spy:3.9.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
@@ -13,7 +13,13 @@ public class MatchInfoResponse {
   @Schema(description = "id", example = "매치 id")
   private Long id;
 
-  //장소
+  @Schema(description = "홈팀 ID")
+  private Long homeTeamId;
+
+  @Schema(description = "어웨이팀 ID")
+  private Long awayTeamId;
+
+    //장소
   @Schema(description = "장소", example = "경기 장소")
   private String stadium;
   //날짜
@@ -54,7 +60,7 @@ public class MatchInfoResponse {
   public MatchInfoResponse(Long id, String stadium, LocalDate matchDate, LocalTime startTime,
       LocalTime endTime, String mainRefereeName, String assistantReferee1,
       String assistantReferee2, String fourthReferee,
-      LocalTime firstHalfStartTime, LocalTime secondHalfStartTime) {
+      LocalTime firstHalfStartTime, LocalTime secondHalfStartTime,Long homeTeamId, Long awayTeamId) {
     this.id = id;
     this.stadium = stadium;
     this.matchDate = matchDate;
@@ -66,5 +72,7 @@ public class MatchInfoResponse {
     this.fourthReferee = fourthReferee;
     this.firstHalfStartTime = firstHalfStartTime;
     this.secondHalfStartTime = secondHalfStartTime;
+    this.homeTeamId = homeTeamId;
+    this.awayTeamId = awayTeamId;
   }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
@@ -18,6 +18,8 @@ public class MatchMapper {
         .fourthReferee(match.getFourthReferee())
         .firstHalfStartTime(match.getFirstHalfStartTime())
         .secondHalfStartTime(match.getSecondHalfStartTime())
+        .homeTeamId(match.getHomeTeam().getId()) // 추가
+        .awayTeamId(match.getAwayTeam().getId()) // 추가
         .build();
   }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/EventTypeCount.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/EventTypeCount.java
@@ -1,0 +1,6 @@
+package com.matchday.matchdayserver.matchevent.model.dto;
+
+public interface EventTypeCount {//쿼리 결과를 맵핑시키기 위해 사용 (인터페이스 DTO)
+    String getEventType();
+    Long getCount();
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.matchevent.repository;
 
+import com.matchday.matchdayserver.matchevent.model.dto.EventTypeCount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
@@ -20,4 +21,18 @@ public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
     List<MatchEvent> findByMatchId(Long matchId);
            
     void deleteByMatchId(Long matchId);
+
+    @Query(value = """
+    SELECT 
+      event_type AS eventType,
+      COUNT(*) AS count
+    FROM match_event
+    WHERE match_user_id = :matchUserId
+      AND match_id = :matchId
+    GROUP BY event_type
+    """, nativeQuery = true)
+    List<EventTypeCount> countEventTypesByMatchUserAndMatch(
+        @Param("matchUserId") Long matchUserId,
+        @Param("matchId") Long matchId
+    );
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -34,7 +34,7 @@ public class MatchEventQueryService {
             } else if ("ASSISTS".equals(eventType)) {
                 assists = count.intValue();
             } else if ("YELLOW_CARD".equals(eventType)||"RED_CARD".equals(eventType)) {
-                cards = count.intValue();
+                cards += count.intValue();
             }
         }
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -1,0 +1,48 @@
+package com.matchday.matchdayserver.matchevent.service;
+
+import com.matchday.matchdayserver.matchevent.model.dto.EventTypeCount;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserEventStat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MatchEventQueryService {
+
+    private MatchEventRepository matchEventRepository;
+    /**
+     * MatchEventStrategy
+     * <p>
+     * 특정 경기에서 특정 선수에 대한 득점,어시스트,파울 개수를 조회합니다
+     * <p>
+     */
+    public MatchUserEventStat getMatchUserEventStat(Long matchId,Long matchUserId) {
+        int goals=0;
+        int assists=0;
+        int cards=0;
+
+        //쿼리 결과 받아서 변수에 대입
+        List<EventTypeCount> eventTypeCounts= matchEventRepository.countEventTypesByMatchUserAndMatch(matchId,matchUserId);
+        for (EventTypeCount eventTypeCount : eventTypeCounts) {
+            String eventType = eventTypeCount.getEventType();
+            Long count = eventTypeCount.getCount();
+
+            if ("GOALS".equals(eventType)) {
+                goals = count.intValue();
+            } else if ("ASSISTS".equals(eventType)) {
+                assists = count.intValue();
+            } else if ("YELLOW_CARD".equals(eventType)||"RED_CARD".equals(eventType)) {
+                cards = count.intValue();
+            }
+        }
+
+        //쿼리로 얻은 변수로 DTO 만들어 결과값으로 리턴
+        return MatchUserEventStat.builder().
+            goals(goals).
+            assists(assists).
+            cards(cards).
+            build();
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -11,7 +11,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MatchEventQueryService {
 
-    private MatchEventRepository matchEventRepository;
+    private final MatchEventRepository matchEventRepository;
     /**
      * MatchEventStrategy
      * <p>

--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
@@ -2,24 +2,35 @@ package com.matchday.matchdayserver.matchuser.controller;
 
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserGroupResponse;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserResponse;
+import com.matchday.matchdayserver.matchuser.model.mapper.MatchUserMapper;
 import com.matchday.matchdayserver.matchuser.service.MatchUserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @Tag(name = "match-users", description = "매치 유저 관련 API")
 @RestController
 @RequestMapping("/api/v1/matches")
 @RequiredArgsConstructor
 public class MatchUserController {
-    private final MatchUserService matchPlayerService;
+    private final MatchUserService matchUserService;
 
     @Operation(summary = "매치 유저 등록", description = "{matchID}에 사용자(user)가 등록됩니다.")
     @PostMapping("/{matchId}/users")
     public ApiResponse<Long> createMatch(@PathVariable Long matchId,
                                            @RequestBody MatchUserCreateRequest request) {
-        Long id = matchPlayerService.create(matchId, request);
+        Long id = matchUserService.create(matchId, request);
         return ApiResponse.ok(id);
+    }
+
+    @Operation(summary = "매치에 출전한 선수들 조회", description = "경기 id를 입력받아 hometeam/awayteam 으로 그룹핑하여 응답합니다")
+    @GetMapping("/{matchId}/players")
+    public ApiResponse<MatchUserGroupResponse> getGroupedMatchUsers(@PathVariable Long matchId) {
+        MatchUserGroupResponse groupedUsers = matchUserService.getGroupedMatchUsers(matchId);
+        return ApiResponse.ok(groupedUsers);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
@@ -1,0 +1,21 @@
+package com.matchday.matchdayserver.matchuser.model.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatchUserEventStat {
+    //MatchEventQueryService에서 MatchUserService로 선수별 주요 이벤트 통계 데이터 전달 시 사용합니다
+    private Integer goals;
+    private Integer assists;
+    private Integer cards;
+
+    @Builder
+    public MatchUserEventStat(Integer goals, Integer assists, Integer cards) {
+        this.goals = goals;
+        this.assists = assists;
+        this.cards = cards;
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserGroupResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserGroupResponse.java
@@ -1,0 +1,16 @@
+package com.matchday.matchdayserver.matchuser.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+public class MatchUserGroupResponse {
+    private List<MatchUserResponse> homeTeam;
+    private List<MatchUserResponse> awayTeam;
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.matchuser.model.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -7,12 +8,25 @@ import lombok.Setter;
 @Setter
 public class MatchUserResponse {
 
-    private Long id;
+    private Long id; //선수의 아이디
     private String name; //이름
     //축구 선수에게만 필요한 필드
     private Integer number; //등번호
     private String matchPosition; // 주의: defaultPosition 과 matchPostition은 다름
+    private String matchGrid;
     private Integer goals;        // 누적 득점
     private Integer assists;      // 누적 어시스트
     private Integer cards;        // 누적 카드 개수 (엘로,레드 합산)
+
+    @Builder
+    public MatchUserResponse(Long id,String name,Integer number, String matchPosition, String matchGrid, Integer goals, Integer assists, Integer cards) {
+        this.id = id;
+        this.name = name;
+        this.number = number;
+        this.matchPosition = matchPosition;
+        this.matchGrid = matchGrid;
+        this.goals = goals;
+        this.assists = assists;
+        this.cards = cards;
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -1,0 +1,18 @@
+package com.matchday.matchdayserver.matchuser.model.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MatchUserResponse {
+
+    private Long id;
+    private String name; //이름
+    //축구 선수에게만 필요한 필드
+    private Integer number; //등번호
+    private String matchPosition; // 주의: defaultPosition 과 matchPostition은 다름
+    private Integer goals;        // 누적 득점
+    private Integer assists;      // 누적 어시스트
+    private Integer cards;        // 누적 카드 개수 (엘로,레드 합산)
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -22,4 +22,5 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
   @Query("SELECT mu.match.id FROM MatchUser mu WHERE mu.user.id = :userId")
   List<Long> findMatchIdsByUserId(@Param("userId") Long userId);
 
+  List<MatchUser> findByMatchId(Long matchId);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -107,6 +107,8 @@ public class MatchUserService {
             } else if (teamId.equals(awayTeamId)) {
                 awayTeamResponses.add(response);
             }
+            // teamId가 null이거나 홈팀/어웨이팀이 아닌 경우 처리가 필요하다면 여기에 추가
+            // ex 기록원,심판
         }
 
         return MatchUserGroupResponse.builder()

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -68,6 +68,8 @@ public class MatchUserService {
     return matchUser.getId();
   }
 
+
+  @Transactional
     public MatchUserGroupResponse getGroupedMatchUsers(Long matchId) {
         List<MatchUser> matchUsers = matchUserRepository.findByMatchId(matchId);
 

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -7,7 +7,12 @@ import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.common.response.UserStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.matchevent.service.MatchEventQueryService;
+import com.matchday.matchdayserver.matchevent.service.MatchEventStrategy;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserEventStat;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserGroupResponse;
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserResponse;
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
 import com.matchday.matchdayserver.matchuser.model.enums.MatchUserRole;
 import com.matchday.matchdayserver.matchuser.model.mapper.MatchUserMapper;
@@ -16,9 +21,13 @@ import com.matchday.matchdayserver.team.model.entity.Team;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.repository.UserRepository;
+import com.matchday.matchdayserver.userteam.model.entity.UserTeam;
+import com.matchday.matchdayserver.userteam.repository.UserTeamRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -29,6 +38,8 @@ public class MatchUserService {
   private final MatchRepository matchRepository;
   private final UserRepository userRepository;
   private final TeamRepository teamRepository;
+  private final MatchEventQueryService matchEventQueryService;
+  private final UserTeamRepository userTeamRepository;
 
   @Transactional
   public Long create(Long matchId, MatchUserCreateRequest request) {
@@ -56,6 +67,53 @@ public class MatchUserService {
     matchUserRepository.save(matchUser);
     return matchUser.getId();
   }
+
+    public MatchUserGroupResponse getGroupedMatchUsers(Long matchId) {
+        List<MatchUser> matchUsers = matchUserRepository.findByMatchId(matchId);
+
+        // 홈팀/어웨이팀 ID 조회
+        Match match = matchRepository.findById(matchId)
+            .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
+        Long homeTeamId = match.getHomeTeam().getId();
+        Long awayTeamId = match.getAwayTeam().getId();
+
+        List<MatchUserResponse> homeTeamResponses = new ArrayList<>();
+        List<MatchUserResponse> awayTeamResponses = new ArrayList<>();
+
+        for (MatchUser matchUser : matchUsers) {
+            Long userId = matchUser.getUser().getId();
+            String userName = matchUser.getUser().getName();
+
+            Long teamId = matchUser.getTeam().getId();
+            UserTeam userTeam = userTeamRepository.findByUserIdAndTeamId(userId, teamId);
+            Integer number = userTeam.getNumber();
+
+            MatchUserEventStat stat = matchEventQueryService.getMatchUserEventStat(matchId, matchUser.getId());
+
+            MatchUserResponse response = MatchUserResponse.builder()
+                .id(userId)
+                .name(userName)
+                .number(number)
+                .goals(stat.getGoals())
+                .assists(stat.getAssists())
+                .cards(stat.getCards())
+                .matchPosition(matchUser.getMatchPosition())
+                .matchGrid(matchUser.getMatchGrid())
+                .build();
+
+            // 홈팀/어웨이팀 분류
+            if (teamId.equals(homeTeamId)) {
+                homeTeamResponses.add(response);
+            } else if (teamId.equals(awayTeamId)) {
+                awayTeamResponses.add(response);
+            }
+        }
+
+        return MatchUserGroupResponse.builder()
+            .homeTeam(homeTeamResponses)
+            .awayTeam(awayTeamResponses)
+            .build();
+    }
 
   /**
    * 팀이 매치에 포함되어 있지 않은지 확인하는 메서드

--- a/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
@@ -24,4 +24,5 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     @Query("SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId AND ut.isActive = true")
     List<Long> findActiveTeamIdsByUserId(@Param("userId") Long userId);
 
+    UserTeam findByUserIdAndTeamId(Long userId, Long teamId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-136

## Overview
- 기존 https://github.com/matchday-team/matchday-api/pull/67 PR에
 테이블 변경 사항을 반영하여 리팩토링하였습니다 로직 및 요청값이 간편하게 개선되었습니다
- 매치 아이디로 요청시
매치에 참여하는 선수들의 기록 정보가
```
    private Long id; //선수의 아이디
    private String name; //이름
    private Integer number; //등번호
    private String matchPosition; 
    private String matchGrid; 
    private Integer goals;        // 누적 득점
    private Integer assists;      // 누적 어시스트
    private Integer cards;        // 누적 카드 개수 (엘로,레드 합산)
``` 
홈팀/어웨이팀으로 그룹핑 되어 응답하는 API를 구현하였습니다.

### Swagger
![image](https://github.com/user-attachments/assets/700c4668-a73d-415c-81d4-6d45ccad749e)

### 응답 예시
```
{
  "status": 200,
  "data": {
    "homeTeam": [
      {
        "id": 1,
        "name": "선수1",
        "number": 7,
        "matchPosition": "FW",
        "matchGrid": "A1",
        "goals": 0,
        "assists": 0,
        "cards": 0
      },
      {
        "id": 2,
        "name": "선수2",
        "number": 7,
        "matchPosition": "FW",
        "matchGrid": "A1",
        "goals": 0,
        "assists": 0,
        "cards": 0
      },
      {
        "id": 3,
        "name": "선수3",
        "number": 7,
        "matchPosition": "FW",
        "matchGrid": "A1",
        "goals": 0,
        "assists": 0,
        "cards": 0
      }
    ],
    "awayTeam": [
      {
        "id": 4,
        "name": "선수4",
        "number": 7,
        "matchPosition": "FW",
        "matchGrid": "A1",
        "goals": 0,
        "assists": 0,
        "cards": 0
      },
      {
        "id": 5,
        "name": "선수5",
        "number": 7,
        "matchPosition": "FW",
        "matchGrid": "A1",
        "goals": 0,
        "assists": 0,
        "cards": 0
      },
      {
        "id": 6,
        "name": "선수6",
        "number": 7,
        "matchPosition": "FW",
        "matchGrid": "A1",
        "goals": 0,
        "assists": 0,
        "cards": 0
      }
    ]
  },
  "message": "OK"
}
```







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 경기 정보 응답에 홈팀 ID와 어웨이팀 ID가 추가되었습니다.
    - 특정 경기의 선수(매치 유저)들을 홈팀/어웨이팀별로 그룹화하여 조회하는 API가 추가되었습니다.
    - 선수별 득점, 도움, 카드 등 주요 이벤트 통계 정보를 제공하는 기능이 추가되었습니다.
- **환경설정**
    - Hibernate DDL 설정이 환경 변수로 외부에서 제어되도록 변경되었습니다.
    - 민감 정보 파일이 git 추적에서 제외됩니다.
    - p6spy 라이브러리가 빌드에 추가되었습니다.
- **버그 수정**
    - 없음
<!-- end of auto-generated comment: release notes by coderabbit.ai -->