### PR TITLE
[MAT-146] 매치 리스트 조회 API

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -4,6 +4,7 @@ import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.match.model.dto.request.MatchCreateRequest;
 import com.matchday.matchdayserver.match.model.dto.request.MatchMemoRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchMemoResponse;
 import com.matchday.matchdayserver.match.service.MatchCreateService;
@@ -18,7 +19,9 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
 
 @Tag(name = "matches", description = "매치 관련 API")
 @RestController
@@ -66,5 +69,14 @@ public class MatchController {
         @Parameter(description = "경기 ID") @PathVariable Long matchId,
         @Parameter(description = "팀 ID") @PathVariable Long teamId) {
       return ApiResponse.ok(matchService.get(matchId, teamId));
+    }
+
+    @Operation(summary = "매치 리스트 조회", description = "특정 팀이 속한 매치 리스트를 조회합니다. <br> 경기 상태(matchStatus) 값은 SCHEDULED(경기 전), IN_PLAY(경기중), FINISHED(경기 종료) 입니다.")
+    @GetMapping("/api/{teamId}/matches")
+    public ApiResponse<List<MatchListResponse>> getMatchList(@PathVariable Long teamId) {
+        List<MatchListResponse> matchList;
+        matchList = matchService.getMatchListByTeam(teamId);
+
+        return ApiResponse.ok(matchList);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchListResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchListResponse.java
@@ -1,0 +1,67 @@
+package com.matchday.matchdayserver.match.model.dto.response;
+
+import com.matchday.matchdayserver.match.model.enums.MatchStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalTime;
+
+@Getter
+public class MatchListResponse {
+  //매치 id, 팀id, 매치 시간, 제목, 장소, 팀, 스코어, 진행 여부
+    @Schema(description = "매치 ID", example = "1")
+    private Long matchId;
+
+    @Schema(description = "홈팀 ID", example = "1")
+    private Long homeTeamId;
+
+    @Schema(description = "홈팀명", example = "토트넘")
+    private String homeTeamName;
+
+    @Schema(description = "상대팀 ID", example = "2")
+    private Long awayTeamId;
+
+    @Schema(description = "상대팀명" , example = "레알 마드리드")
+    private String awayTeamName;
+
+    @Schema(description = "매치명", example = "프리미어리그 결승")
+    private String matchTitle;
+
+    @Schema(description = "매치 시작 시간")
+    private LocalTime matchStartTime;
+
+    @Schema(description = "매치 종료 시간")
+    private LocalTime matchEndTime;
+
+    @Schema(description = "매치 장소", example = "토트넘 스타디움")
+    private String stadium;
+
+    @Schema(description = "홈팀 스코어", example = "3")
+    private int homeScore;
+
+    @Schema(description = "상대팀 스코어", example = "1")
+    private int awayScore;
+
+    @Schema(description = "경기 진행 여부", example = "FINISHED")
+     private MatchStatus matchStatus;  //경기 상태 (시작 전, 진행 중, 종료)
+
+    @Builder
+    public MatchListResponse(Long matchId, Long homeTeamId, String homeTeamName,
+        Long awayTeamId, String awayTeamName, String matchTitle,
+        LocalTime matchStartTime, LocalTime matchEndTime, String stadium,
+        int homeScore, int awayScore,
+        MatchStatus matchStatus) {
+        this.matchId = matchId;
+        this.homeTeamId = homeTeamId;
+        this.homeTeamName = homeTeamName;
+        this.awayTeamId = awayTeamId;
+        this.awayTeamName = awayTeamName;
+        this.matchTitle = matchTitle;
+        this.matchStartTime = matchStartTime;
+        this.matchEndTime = matchEndTime;
+        this.stadium = stadium;
+        this.homeScore = homeScore;
+        this.awayScore = awayScore;
+        this.matchStatus = matchStatus;
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -75,8 +75,17 @@ public class Match {
     @Column(name = "away_team_memo", nullable = true)
     private String awayTeamMemo;  //홈팀 메모
 
+    @Column(name = "match_status")
+    private MatchStatus matchStatus;  //경기 상태 (시작 전, 진행 중, 종료)
+
     public enum MatchType {
         리그, 대회, 친선경기
+    }
+
+    public enum MatchStatus {
+        SCHEDULED,  // 경기 전
+        IN_PLAY,    // 진행 중
+        FINISHED    //경기 종료
     }
 
     public void updateHomeTeamMemo(String memo) {

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.match.model.entity;
 
+import com.matchday.matchdayserver.match.model.enums.MatchStatus;
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import jakarta.persistence.*;
@@ -75,17 +76,12 @@ public class Match {
     @Column(name = "away_team_memo", nullable = true)
     private String awayTeamMemo;  //홈팀 메모
 
-    @Column(name = "match_status")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "match_status", nullable = false, columnDefinition = "VARCHAR(50) DEFAULT 'SCHEDULED'")
     private MatchStatus matchStatus;  //경기 상태 (시작 전, 진행 중, 종료)
 
     public enum MatchType {
         리그, 대회, 친선경기
-    }
-
-    public enum MatchStatus {
-        SCHEDULED,  // 경기 전
-        IN_PLAY,    // 진행 중
-        FINISHED    //경기 종료
     }
 
     public void updateHomeTeamMemo(String memo) {
@@ -98,7 +94,7 @@ public class Match {
 
     @Builder
     public Match(String title, Team homeTeam, Team awayTeam, MatchType matchType, String stadium, LocalDate matchDate,
-        LocalTime startTime, LocalTime endTime, LocalTime firstHalfStartTime, LocalTime secondHalfStartTime, String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee) {
+        LocalTime startTime, LocalTime endTime, LocalTime firstHalfStartTime, LocalTime secondHalfStartTime, String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee, MatchStatus matchStatus) {
       this.title = title;
       this.homeTeam = homeTeam;
       this.awayTeam = awayTeam;
@@ -113,6 +109,7 @@ public class Match {
       this.assistantReferee1 = assistantReferee1;
       this.assistantReferee2 = assistantReferee2;
       this.fourthReferee = fourthReferee;
+      this.matchStatus = matchStatus;
     }
 
     @OneToMany(mappedBy = "match",cascade = CascadeType.REMOVE)

--- a/src/main/java/com/matchday/matchdayserver/match/model/enums/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/enums/MatchStatus.java
@@ -1,0 +1,7 @@
+package com.matchday.matchdayserver.match.model.enums;
+
+public enum MatchStatus {
+    SCHEDULED,  // 경기 전
+    IN_PLAY,    // 진행 중
+    FINISHED
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
@@ -1,8 +1,12 @@
 package com.matchday.matchdayserver.match.model.mapper;
 
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.entity.Match;
+import org.springframework.stereotype.Component;
 
+@Component
 public class MatchMapper {
   //Match -> MatchInfoResponse 변환
   public static MatchInfoResponse toResponse(Match match) {
@@ -20,4 +24,21 @@ public class MatchMapper {
         .secondHalfStartTime(match.getSecondHalfStartTime())
         .build();
   }
+
+    public MatchListResponse toMatchListResponse(Match match, MatchScoreResponse scoreResponse) {
+        return MatchListResponse.builder()
+            .matchId(match.getId())
+            .homeTeamId(match.getHomeTeam().getId())
+            .homeTeamName(match.getHomeTeam().getName())
+            .awayTeamId(match.getAwayTeam().getId())
+            .awayTeamName(match.getAwayTeam().getName())
+            .matchTitle(match.getTitle())
+            .matchStartTime(match.getStartTime())
+            .matchEndTime(match.getEndTime())
+            .stadium(match.getStadium())
+            .homeScore(scoreResponse.getHomeScore().getGoalCount())
+            .awayScore(scoreResponse.getAwayScore().getGoalCount())
+            .matchStatus(match.getMatchStatus())
+            .build();
+    }
 }


### PR DESCRIPTION
## Related Issue

[MAT-146](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-146)

## Overview
1. Match 테이블에 매치 상태를 표현하는 'match_status' 컬럼 추가 했습니다. 
   ENUM 값은 `SCHEDULED` : 경기 전  / `IN_PLAY` : 경기 중 /`FINISHED` : 경기 종료 입니다
3. 특정 팀이 속한 매치 리스트 조회 API 구현

## Screenshot
<img width="720" alt="스크린샷 2025-05-03 오후 2 50 00" src="https://github.com/user-attachments/assets/991191d3-89bf-4886-affe-b68b2cab2ed4" />

