### PR TITLE
[MAT-131] 전,후반 시간 기록 API

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
@@ -16,7 +16,7 @@ public enum MatchStatus implements StatusInterface {
     DIFFERENT_TEAM_EXCHANGE(400, 6013, "서로 다른 팀의 선수는 교체할 수 없습니다"),
     INVALID_HALF_TYPE(400, 6014,"잘못된 HALF 타입입니다"),
     INVALID_TIME_RANGE(400, 6015,"종료 시간은 시작 시간보다 늦어야합니다"),
-    SECOND_HALF_TIME_ERRO(400, 6016,"후반 시작 시간은 전반 종료 시간 보다 늦어야합니다")
+    SECOND_HALF_TIME_ERROR(400, 6016,"후반 시작 시간은 전반 종료 시간 보다 늦어야합니다")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
@@ -6,7 +6,7 @@ public enum MatchStatus implements StatusInterface {
     SAME_TEAM_ERROR(400, 6003, "홈 팀과 어웨이 팀은 동일할 수 없습니다"),
     INVALID_STADIUM(400, 6004, "경기장을 입력하세요"),
     INVALID_DATE(400, 6005, "과거 날짜는 등록할 수 없습니다"),
-    INVALID_TIME(400, 6006, "시작시간이 종료시간 보다 늦을 수 없습니다"),
+    TIME_ORDER_INVALID(400, 6006, "시작 시간은 종료시간 보다 빨라야합니다"),
     NOTFOUND_MATCH(404, 6007, "존재하지 않는 매치 입니다"),
     NOT_PARTICIPATING_PLAYER(400, 6008, "경기에 참여중이지 않은 선수입니다"),
     UNAUTHORIZED_RECORD(403, 6009, "기록할 수 없는 유저입니다"),
@@ -14,7 +14,9 @@ public enum MatchStatus implements StatusInterface {
     TEAM_NOT_PARTICIPATING(400, 6011, "해당 팀은 입력받은 경기의 홈팀도, 어웨이팀도 아닙니다."),
     MEMO_NOT_FOUND(404, 6012, "존재하지 않는 매모 입니다"),
     DIFFERENT_TEAM_EXCHANGE(400, 6013, "서로 다른 팀의 선수는 교체할 수 없습니다"),
-    INVALID_HALF_TYPE(400, 6014,"잘못된 HALF 타입입니다")
+    INVALID_HALF_TYPE(400, 6014,"잘못된 HALF 타입입니다"),
+    INVALID_TIME_RANGE(400, 6015,"종료 시간은 시작 시간보다 늦어야합니다"),
+    SECOND_HALF_TIME_ERRO(400, 6016,"후반 시작 시간은 전반 종료 시간 보다 늦어야합니다")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
@@ -13,7 +13,8 @@ public enum MatchStatus implements StatusInterface {
     SOCKET_ERROR(500, 6010, "웹소켓 오류"),
     TEAM_NOT_PARTICIPATING(400, 6011, "해당 팀은 입력받은 경기의 홈팀도, 어웨이팀도 아닙니다."),
     MEMO_NOT_FOUND(404, 6012, "존재하지 않는 매모 입니다"),
-    DIFFERENT_TEAM_EXCHANGE(400, 6013, "서로 다른 팀의 선수는 교체할 수 없습니다")
+    DIFFERENT_TEAM_EXCHANGE(400, 6013, "서로 다른 팀의 선수는 교체할 수 없습니다"),
+    INVALID_HALF_TYPE(400, 6014,"잘못된 HALF 타입입니다")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -3,6 +3,7 @@ package com.matchday.matchdayserver.match.controller;
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.match.model.dto.request.MatchCreateRequest;
 import com.matchday.matchdayserver.match.model.dto.request.MatchMemoRequest;
+import com.matchday.matchdayserver.match.model.dto.request.MatchHalfTimeRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
@@ -15,12 +16,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import java.time.LocalTime;
 import java.util.List;
 
 @Tag(name = "matches", description = "매치 관련 API")
@@ -75,5 +77,12 @@ public class MatchController {
     @GetMapping("/teams/{teamId}")
     public ApiResponse<List<MatchListResponse>> getMatchList(@PathVariable Long teamId) {
         return ApiResponse.ok(matchService.getMatchListByTeam(teamId));
+    }
+
+    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> halfType은 전반 `first`, 후반 `second` 입니다.")
+    @PatchMapping("/{matchId}/{halfType}-time")
+    public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @PathVariable String halfType, @RequestBody MatchHalfTimeRequest matchHalfTimeRequest) {
+        matchService.setHalfTime(matchId, halfType, matchHalfTimeRequest);
+        return ApiResponse.ok("시간 등록 완료");
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -79,7 +79,7 @@ public class MatchController {
         return ApiResponse.ok(matchService.getMatchListByTeam(teamId));
     }
 
-    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> halfType은 전반 `first`, 후반 `second` 입니다.")
+    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> halfType은 전반 `first`, 후반 `second` 입니다.<br>각 시간 단건 등록 가능합니다.")
     @PatchMapping("/{matchId}/{halfType}-time")
     public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @PathVariable String halfType, @RequestBody MatchHalfTimeRequest matchHalfTimeRequest) {
         matchService.setHalfTime(matchId, halfType, matchHalfTimeRequest);

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
@@ -2,9 +2,11 @@ package com.matchday.matchdayserver.match.model.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import java.time.LocalTime;
 
 @Getter
+@NoArgsConstructor
 public class MatchHalfTimeRequest {
     @Schema(description = "시작 시간")
     private LocalTime startTime;

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
@@ -1,0 +1,14 @@
+package com.matchday.matchdayserver.match.model.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import java.time.LocalTime;
+
+@Getter
+public class MatchHalfTimeRequest {
+    @Schema(description = "시작 시간")
+    private LocalTime startTime;
+
+    @Schema(description = "종료 시간")
+    private LocalTime endTime;
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -113,7 +113,7 @@ public class Match {
 
     @Builder
     public Match(String title, Team homeTeam, Team awayTeam, MatchType matchType, String stadium, LocalDate matchDate,
-        LocalTime startTime, LocalTime endTime, LocalTime firstHalfStartTime, LocalTime secondHalfStartTime, String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee, MatchStatus matchStatus) {
+        LocalTime startTime, LocalTime endTime, LocalTime firstHalfStartTime, LocalTime firstHalfEndTime, LocalTime secondHalfStartTime, LocalTime secondHalfEndTime, String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee, MatchStatus matchStatus) {
       this.title = title;
       this.homeTeam = homeTeam;
       this.awayTeam = awayTeam;
@@ -123,7 +123,9 @@ public class Match {
       this.startTime = startTime;
       this.endTime = endTime;
       this.firstHalfStartTime = firstHalfStartTime;
+      this.firstHalfEndTime = firstHalfEndTime;
       this.secondHalfStartTime = secondHalfStartTime;
+      this.secondHalfEndTime = secondHalfEndTime;
       this.mainRefereeName = mainRefereeName;
       this.assistantReferee1 = assistantReferee1;
       this.assistantReferee2 = assistantReferee2;

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -42,7 +42,6 @@ public class Match {
     @Column(length = 50, nullable = false)
     private String stadium;
 
-    @FutureOrPresent(message = "과거 일자는 등록할 수 없습니다.") //과거 일자 등록 못하게 제약
     @Column(nullable = false)
     private LocalDate matchDate;
 
@@ -55,8 +54,14 @@ public class Match {
     @Column(name = "first_half_start_time")
     private LocalTime firstHalfStartTime; // 전반 시작 시간
 
+    @Column(name = "first_half_end_time")
+    private LocalTime firstHalfEndTime; // 전반 종료 시간
+
     @Column(name = "second_half_start_time")
     private LocalTime secondHalfStartTime; // 후반 시작 시간
+
+    @Column(name = "second_half_end_time")
+    private LocalTime secondHalfEndTime; // 후반 종료 시간
 
     @Column(name = "main_referee")
     private String mainRefereeName; //주심
@@ -91,6 +96,20 @@ public class Match {
     public void updateAwayTeamMemo(String memo) {
     this.awayTeamMemo = memo;
     }
+
+    public void setFirstHalfStartTime(LocalTime time) {
+        this.firstHalfStartTime = time;
+    }
+    public void setFirstHalfEndTime(LocalTime time) {
+        this.firstHalfEndTime = time;
+    }
+    public void setSecondHalfStartTime(LocalTime time) {
+        this.secondHalfStartTime = time;
+    }
+    public void setSecondHalfEndTime(LocalTime time) {
+        this.secondHalfEndTime = time;
+    }
+
 
     @Builder
     public Match(String title, Team homeTeam, Team awayTeam, MatchType matchType, String stadium, LocalDate matchDate,

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
@@ -86,7 +86,7 @@ public class MatchCreateService {
     //시작시간이 종료시간 보다 늦으면 예외 발생
     private void validateTime(LocalTime startTime, LocalTime endTime) {
         if (startTime.isAfter(endTime)) {
-            throw new ApiException(MatchStatus.INVALID_TIME);  // 시작 시간이 종료 시간보다 늦을 경우
+            throw new ApiException(MatchStatus.TIME_ORDER_INVALID);  // 시작 시간이 종료 시간보다 늦을 경우
         }
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -137,7 +137,7 @@ public class MatchService {
             // 후반 시작 시간이 전반 종료 시간보다 늦은지 검증
             if (newSecondHalfStart != null && match.getFirstHalfEndTime() != null &&
                 newSecondHalfStart.isBefore(match.getFirstHalfEndTime())) {
-                throw new ApiException(MatchStatus.SECOND_HALF_TIME_ERRO);
+                throw new ApiException(MatchStatus.SECOND_HALF_TIME_ERROR);
             }
             if (newSecondHalfStart != null) {
                 match.setSecondHalfStartTime(newSecondHalfStart);

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -3,6 +3,7 @@ package com.matchday.matchdayserver.match.service;
 import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.MatchStatus;
 import com.matchday.matchdayserver.common.response.TeamStatus;
+import com.matchday.matchdayserver.match.model.dto.request.MatchHalfTimeRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
@@ -91,4 +92,32 @@ public class MatchService {
           })
           .collect(Collectors.toList());
   }
+
+    @Transactional
+    public void setHalfTime(Long id, String halfType, MatchHalfTimeRequest halfTimeRequest) {
+        Match match = matchRepository.findById(id)
+            .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
+
+        // 전반/후반 구분 처리
+        if ("first".equalsIgnoreCase(halfType)) {
+            if (halfTimeRequest.getStartTime() != null) {
+                match.setFirstHalfStartTime(halfTimeRequest.getStartTime());
+            }
+            if (halfTimeRequest.getEndTime() != null) {
+                match.setFirstHalfEndTime(halfTimeRequest.getEndTime());
+            }
+        } else if ("second".equalsIgnoreCase(halfType)) {
+            if (halfTimeRequest.getStartTime() != null) {
+                match.setSecondHalfStartTime(halfTimeRequest.getStartTime());
+            }
+            if (halfTimeRequest.getEndTime() != null) {
+                match.setSecondHalfEndTime(halfTimeRequest.getEndTime());
+            }
+        } else {
+            throw new ApiException(MatchStatus.INVALID_HALF_TYPE);
+        }
+
+        matchRepository.save(match);
+    }
+
 }

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -16,6 +16,7 @@ import com.matchday.matchdayserver.team.repository.TeamRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -97,26 +98,56 @@ public class MatchService {
     public void setHalfTime(Long id, String halfType, MatchHalfTimeRequest halfTimeRequest) {
         Match match = matchRepository.findById(id)
             .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
-
         // 전반/후반 구분 처리
         if ("first".equalsIgnoreCase(halfType)) {
-            if (halfTimeRequest.getStartTime() != null) {
-                match.setFirstHalfStartTime(halfTimeRequest.getStartTime());
+            LocalTime currentFirstHalfStart = match.getFirstHalfStartTime();
+            LocalTime newFirstHalfStart   = halfTimeRequest.getStartTime();
+            LocalTime newFirstHalfEnd     = halfTimeRequest.getEndTime();
+
+            // 시작 시간만 업데이트하는 경우 종료 시간과의 관계 검증
+            if (newFirstHalfStart != null && match.getFirstHalfEndTime() != null &&
+                newFirstHalfStart.isAfter(match.getFirstHalfEndTime())) {
+                throw new ApiException(MatchStatus.TIME_ORDER_INVALID);
             }
-            if (halfTimeRequest.getEndTime() != null) {
-                match.setFirstHalfEndTime(halfTimeRequest.getEndTime());
+            // 종료 시간만 업데이트하는 경우 시작 시간과의 관계 검증
+            if (newFirstHalfEnd != null && currentFirstHalfStart != null &&
+                newFirstHalfEnd.isBefore(currentFirstHalfStart)) {
+                throw new ApiException(MatchStatus.INVALID_TIME_RANGE);
+            }
+            if (newFirstHalfStart != null) {
+                match.setFirstHalfStartTime(newFirstHalfStart);
+            }
+            if (newFirstHalfEnd != null) {
+                match.setFirstHalfEndTime(newFirstHalfEnd);
             }
         } else if ("second".equalsIgnoreCase(halfType)) {
-            if (halfTimeRequest.getStartTime() != null) {
-                match.setSecondHalfStartTime(halfTimeRequest.getStartTime());
+            LocalTime currentSecondHalfStart = match.getSecondHalfStartTime();
+            LocalTime newSecondHalfStart     = halfTimeRequest.getStartTime();
+            LocalTime newSecondHalfEnd       = halfTimeRequest.getEndTime();
+            // 시작 시간만 업데이트하는 경우 종료 시간과의 관계 검증
+            if (newSecondHalfStart != null && match.getSecondHalfEndTime() != null &&
+                newSecondHalfStart.isAfter(match.getSecondHalfEndTime())) {
+                throw new ApiException(MatchStatus.TIME_ORDER_INVALID);
             }
-            if (halfTimeRequest.getEndTime() != null) {
-                match.setSecondHalfEndTime(halfTimeRequest.getEndTime());
+            // 종료 시간만 업데이트하는 경우 시작 시간과의 관계 검증
+            if (newSecondHalfEnd != null && currentSecondHalfStart != null &&
+                newSecondHalfEnd.isBefore(currentSecondHalfStart)) {
+                throw new ApiException(MatchStatus.INVALID_TIME_RANGE);
+            }
+            // 후반 시작 시간이 전반 종료 시간보다 늦은지 검증
+            if (newSecondHalfStart != null && match.getFirstHalfEndTime() != null &&
+                newSecondHalfStart.isBefore(match.getFirstHalfEndTime())) {
+                throw new ApiException(MatchStatus.SECOND_HALF_TIME_ERRO);
+            }
+            if (newSecondHalfStart != null) {
+                match.setSecondHalfStartTime(newSecondHalfStart);
+            }
+            if (newSecondHalfEnd != null) {
+                match.setSecondHalfEndTime(newSecondHalfEnd);
             }
         } else {
             throw new ApiException(MatchStatus.INVALID_HALF_TYPE);
         }
-
         matchRepository.save(match);
     }
 


### PR DESCRIPTION
## Related Issue
[MAT-131](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-131)

## Overview

전/후반 시작/종료 시간 Patch API입니다.
시간 단건 등록도 가능합니다.

## Screenshot
<img width="725" alt="스크린샷 2025-05-04 오후 2 51 58" src="https://github.com/user-attachments/assets/02278a1c-34c2-4d58-a47d-f22b5b0e97b2" />






[MAT-131]: https://match-day.atlassian.net/browse/MAT-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 경기의 전반 또는 후반 시작 및 종료 시간을 등록할 수 있는 PATCH 엔드포인트가 추가되었습니다.
    - 전반/후반 시간 등록을 위한 요청 데이터 형식이 도입되었습니다.
- **개선 사항**
    - 경기 날짜를 과거로도 설정할 수 있도록 제한이 완화되었습니다.
    - 경기 엔터티에 전반/후반 종료 시간이 추가되어 더 정밀한 시간 관리가 가능합니다.
- **버그 수정**
    - 잘못된 HALF 타입 요청 시 명확한 오류 메시지가 제공됩니다.
    - 시간 순서 오류에 대한 상태 코드 및 메시지가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->