### PR TITLE
[MAT-158] MAT-4  MAT-158   팀 별 경기 출전하는 선수 명단 조회 교체/선발 구분

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -18,31 +18,26 @@ public class MatchEventQueryService {
      * 특정 경기에서 특정 선수에 대한 득점,어시스트,파울 개수를 조회합니다
      * <p>
      */
-    public MatchUserEventStat getMatchUserEventStat(Long matchId,Long matchUserId) {
-        int goals=0;
-        int assists=0;
-        int cards=0;
+    public MatchUserEventStat getMatchUserEventStat(Long matchId, Long matchUserId) {
+        int goals = 0, assists = 0, yellowCards = 0, redCards = 0;
 
-        //쿼리 결과 받아서 변수에 대입
-        List<EventTypeCount> eventTypeCounts= matchEventRepository.countEventTypesByMatchUserAndMatch(matchId,matchUserId);
-        for (EventTypeCount eventTypeCount : eventTypeCounts) {
-            String eventType = eventTypeCount.getEventType();
-            Long count = eventTypeCount.getCount();
-
-            if ("GOALS".equals(eventType)) {
-                goals = count.intValue();
-            } else if ("ASSISTS".equals(eventType)) {
-                assists = count.intValue();
-            } else if ("YELLOW_CARD".equals(eventType)||"RED_CARD".equals(eventType)) {
-                cards += count.intValue();
+        List<EventTypeCount> counts = matchEventRepository.countEventTypesByMatchUserAndMatch(matchId, matchUserId);
+        for (EventTypeCount c : counts) {
+            switch (c.getEventType()) {
+                case "GOALS" -> goals = c.getCount().intValue();
+                case "ASSISTS" -> assists = c.getCount().intValue();
+                case "YELLOW_CARD" -> yellowCards = c.getCount().intValue();
+                case "RED_CARD" -> redCards = c.getCount().intValue();
             }
         }
 
-        //쿼리로 얻은 변수로 DTO 만들어 결과값으로 리턴
-        return MatchUserEventStat.builder().
-            goals(goals).
-            assists(assists).
-            cards(cards).
-            build();
+        return MatchUserEventStat.builder()
+            .goals(goals)
+            .assists(assists)
+            .yellowCards(yellowCards)
+            .redCards(redCards)
+            .caution(yellowCards)                 // caution == yellowCards
+            .sentOff(yellowCards >= 2 || redCards >= 1)  // 퇴장 판단
+            .build();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
@@ -7,6 +7,7 @@ import com.matchday.matchdayserver.matchuser.model.dto.MatchUserResponse;
 import com.matchday.matchdayserver.matchuser.model.mapper.MatchUserMapper;
 import com.matchday.matchdayserver.matchuser.service.MatchUserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -27,9 +28,20 @@ public class MatchUserController {
         return ApiResponse.ok(id);
     }
 
-    @Operation(summary = "매치에 출전한 선수들 조회", description = "경기 id를 입력받아 hometeam/awayteam 으로 그룹핑하여 응답합니다")
+    @Operation(
+        summary = "매치 참가 선수 목록 조회",
+        description = """
+            경기 ID를 기반으로 출전 선수 정보를 홈팀/어웨이팀으로 그룹핑하여 반환합니다. 
+            각 팀은 선발(starters)과 교체(substitutes) 선수 목록으로 구분되며, 
+            선수별로 득점, 어시스트, 옐로카드/레드카드 수, 경고 누적 수(caution), 퇴장 여부(sentOff) 정보가 포함됩니다.
+            FIFA 룰 기반 카드 처리 기준을 따릅니다. 경고 누적 수는 옐로 카드로만 결정되며 레드카드 받았을 시 경고가 누적되지 않고 바로 퇴장입니다
+        """
+    )
     @GetMapping("/{matchId}/players")
-    public ApiResponse<MatchUserGroupResponse> getGroupedMatchUsers(@PathVariable Long matchId) {
+    public ApiResponse<MatchUserGroupResponse> getGroupedMatchUsers(
+        @Parameter(description = "매치 ID", example = "1", required = true)
+        @PathVariable Long matchId
+    ) {
         MatchUserGroupResponse groupedUsers = matchUserService.getGroupedMatchUsers(matchId);
         return ApiResponse.ok(groupedUsers);
     }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
@@ -7,15 +7,22 @@ import lombok.Setter;
 @Getter
 @Setter
 public class MatchUserEventStat {
-    //MatchEventQueryService에서 MatchUserService로 선수별 주요 이벤트 통계 데이터 전달 시 사용합니다
     private Integer goals;
     private Integer assists;
-    private Integer cards;
+    private Integer yellowCards;
+    private Integer redCards;
+    private Integer caution;   // == yellowCards
+    private boolean sentOff;   // 퇴장 여부
 
     @Builder
-    public MatchUserEventStat(Integer goals, Integer assists, Integer cards) {
+    public MatchUserEventStat(Integer goals, Integer assists,
+        Integer yellowCards, Integer redCards,
+        Integer caution, boolean sentOff) {
         this.goals = goals;
         this.assists = assists;
-        this.cards = cards;
+        this.yellowCards = yellowCards;
+        this.redCards = redCards;
+        this.caution = caution;
+        this.sentOff = sentOff;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserGroupResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserGroupResponse.java
@@ -1,16 +1,38 @@
 package com.matchday.matchdayserver.matchuser.model.dto;
 
+import com.matchday.matchdayserver.matchuser.model.dto.MatchUserResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.util.List;
 
+@Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@Data
+@Schema(description = "홈팀과 어웨이팀 참가자 정보를 선발/교체로 그룹핑한 응답")
 public class MatchUserGroupResponse {
-    private List<MatchUserResponse> homeTeam;
-    private List<MatchUserResponse> awayTeam;
+
+    @Schema(description = "홈팀 참가자 정보 (선발/교체)")
+    private TeamGroupedUsers homeTeam;
+
+    @Schema(description = "어웨이팀 참가자 정보 (선발/교체)")
+    private TeamGroupedUsers awayTeam;
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(description = "선발 및 교체 참가자 그룹")
+    public static class TeamGroupedUsers {
+
+        @Schema(description = "선발 선수 목록")
+        private List<MatchUserResponse> starters;
+
+        @Schema(description = "교체 선수 목록")
+        private List<MatchUserResponse> substitutes;
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -1,25 +1,52 @@
 package com.matchday.matchdayserver.matchuser.model.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@Schema(description = "매치 참가자 통계 응답")
 public class MatchUserResponse {
 
-    private Long id; //선수의 아이디
-    private String name; //이름
-    //축구 선수에게만 필요한 필드
-    private Integer number; //등번호
-    private String matchPosition; // 주의: defaultPosition 과 matchPostition은 다름
+    @Schema(description = "유저 ID", example = "12")
+    private Long id;
+
+    @Schema(description = "유저 이름", example = "홍길동")
+    private String name;
+
+    @Schema(description = "등번호", example = "10")
+    private Integer number;
+
+    @Schema(description = "매치 포지션", example = "MF")
+    private String matchPosition;
+
+    @Schema(description = "경기장 그리드 위치", example = "B2")
     private String matchGrid;
-    private Integer goals;        // 누적 득점
-    private Integer assists;      // 누적 어시스트
-    private Integer cards;        // 누적 카드 개수 (엘로,레드 합산)
+
+    @Schema(description = "득점 수", example = "2")
+    private Integer goals;
+
+    @Schema(description = "어시스트 수", example = "1")
+    private Integer assists;
+
+    @Schema(description = "옐로카드 수", example = "1")
+    private Integer yellowCards;
+
+    @Schema(description = "레드카드 수", example = "0")
+    private Integer redCards;
+
+    @Schema(description = "경고 누적 수 (옐로카드 개수)", example = "1")
+    private Integer caution;
+
+    @Schema(description = "퇴장 여부 (옐로 2장 이상 또는 레드 1장 이상)", example = "false")
+    private boolean sentOff;
 
     @Builder
-    public MatchUserResponse(Long id,String name,Integer number, String matchPosition, String matchGrid, Integer goals, Integer assists, Integer cards) {
+    public MatchUserResponse(Long id, String name, Integer number, String matchPosition, String matchGrid,
+        Integer goals, Integer assists,
+        Integer yellowCards, Integer redCards, Integer caution, boolean sentOff) {
         this.id = id;
         this.name = name;
         this.number = number;
@@ -27,6 +54,9 @@ public class MatchUserResponse {
         this.matchGrid = matchGrid;
         this.goals = goals;
         this.assists = assists;
-        this.cards = cards;
+        this.yellowCards = yellowCards;
+        this.redCards = redCards;
+        this.caution = caution;
+        this.sentOff = sentOff;
     }
 }


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-158

## Overview

- 팀 별 경기 출전하는 선수 명단 조회 홈팀 어웨이팀 별 교체/선발 구분하여 그룹핑하여 응답
 ```
{
  "homeTeam": {
    "starters": [ ... ],
    "substitutes": [ ... ]
  },
  "awayTeam": {
    "starters": [ ... ],
    "substitutes": [ ... ]
  }
}
```

- 옐로카드,레드카드,퇴장여부,경고개수 응답값에 추가
- 컨트롤러 DTO 등 , 스웨거 명세 개선






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 선수별로 경고(옐로카드), 퇴장(레드카드), 경고 누적, 퇴장 여부 등 카드 관련 통계를 상세하게 구분하여 제공합니다.
    - 홈팀과 어웨이팀 선수 목록이 각각 선발과 교체 선수로 그룹화되어 응답됩니다.

- **문서화**
    - API 문서에 선수 통계(득점, 도움, 옐로카드, 레드카드, 경고, 퇴장 여부)와 그룹화 구조에 대한 설명이 추가되었습니다.
    - 매치 ID 파라미터에 대한 설명과 예시가 API 문서에 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->