### PR TITLE
[MAT-158] fix : 비활동 선수 조회 포함 문제 수정

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -28,6 +28,7 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -86,8 +87,12 @@ public class MatchUserService {
             String userName = matchUser.getUser().getName();
             Long teamId = matchUser.getTeam().getId();
 
-            UserTeam userTeam = userTeamRepository.findByUserIdAndTeamId(userId, teamId);
-            Integer number = userTeam.getNumber();
+            Optional<UserTeam> optionalUserTeam = userTeamRepository.findActiveUserTeamByUserIdAndTeamId(userId, teamId);
+            if (optionalUserTeam.isEmpty()) {
+                continue; // 활동 중이 아니거나 기록이 없으면 무시
+            }
+
+            Integer number = optionalUserTeam.get().getNumber();
 
             MatchUserEventStat stat = matchEventQueryService.getMatchUserEventStat(matchId, matchUser.getId());
 

--- a/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/repository/UserTeamRepository.java
@@ -24,5 +24,9 @@ public interface UserTeamRepository extends JpaRepository<UserTeam, Long> {
     @Query("SELECT ut.team.id FROM UserTeam ut WHERE ut.user.id = :userId AND ut.isActive = true")
     List<Long> findActiveTeamIdsByUserId(@Param("userId") Long userId);
 
-    UserTeam findByUserIdAndTeamId(Long userId, Long teamId);
+    @Query("""
+    SELECT ut FROM UserTeam ut 
+    WHERE ut.user.id = :userId AND ut.team.id = :teamId AND ut.isActive = true
+    """)
+    Optional<UserTeam> findActiveUserTeamByUserIdAndTeamId(@Param("userId") Long userId, @Param("teamId") Long teamId);
 }


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-158

## Overview

선수 조회 쿼리에 is_active 상태 체크 조건 추가










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 비활성화된 사용자-팀 연결이 있는 경우 해당 사용자를 무시하여, 비활성 또는 누락된 사용자-팀 정보로 인한 오류를 방지합니다.  
- **리팩터링**
  - 사용자-팀 정보 조회 시 활성 상태만 반영하도록 내부 처리 방식을 개선하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->