### PR TITLE
[MAT-157] 매치 상태 변경 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchListResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchListResponse.java
@@ -1,6 +1,6 @@
 package com.matchday.matchdayserver.match.model.dto.response;
 
-import com.matchday.matchdayserver.match.model.enums.MatchStatus;
+import com.matchday.matchdayserver.match.model.enums.MatchState;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,7 +8,6 @@ import java.time.LocalTime;
 
 @Getter
 public class MatchListResponse {
-  //매치 id, 팀id, 매치 시간, 제목, 장소, 팀, 스코어, 진행 여부
     @Schema(description = "매치 ID", example = "1")
     private Long matchId;
 
@@ -43,14 +42,14 @@ public class MatchListResponse {
     private int awayScore;
 
     @Schema(description = "경기 진행 여부", example = "FINISHED")
-     private MatchStatus matchStatus;  //경기 상태 (시작 전, 진행 중, 종료)
+     private MatchState matchState;  //경기 상태 (시작 전, 진행 중, 종료)
 
     @Builder
     public MatchListResponse(Long matchId, Long homeTeamId, String homeTeamName,
         Long awayTeamId, String awayTeamName, String matchTitle,
         LocalTime matchStartTime, LocalTime matchEndTime, String stadium,
         int homeScore, int awayScore,
-        MatchStatus matchStatus) {
+        MatchState matchState) {
         this.matchId = matchId;
         this.homeTeamId = homeTeamId;
         this.homeTeamName = homeTeamName;
@@ -62,6 +61,6 @@ public class MatchListResponse {
         this.stadium = stadium;
         this.homeScore = homeScore;
         this.awayScore = awayScore;
-        this.matchStatus = matchStatus;
+        this.matchState = matchState;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -81,7 +81,7 @@ public class Match {
     private String awayTeamMemo;  //홈팀 메모
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "match_status", nullable = false, length = 50, columnDefinition = "VARCHAR(50) DEFAULT 'SCHEDULED'")
+    @Column(name = "match_state", nullable = false, length = 50, columnDefinition = "VARCHAR(50) DEFAULT 'SCHEDULED'")
     private MatchState matchState;  //경기 상태 (시작 전, 진행 중, 종료)
 
     public enum MatchType {

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -1,10 +1,9 @@
 package com.matchday.matchdayserver.match.model.entity;
 
-import com.matchday.matchdayserver.match.model.enums.MatchStatus;
+import com.matchday.matchdayserver.match.model.enums.MatchState;
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import jakarta.persistence.*;
-import jakarta.validation.constraints.FutureOrPresent;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -83,7 +82,7 @@ public class Match {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "match_status", nullable = false, length = 50, columnDefinition = "VARCHAR(50) DEFAULT 'SCHEDULED'")
-    private MatchStatus matchStatus;  //경기 상태 (시작 전, 진행 중, 종료)
+    private MatchState matchState;  //경기 상태 (시작 전, 진행 중, 종료)
 
     public enum MatchType {
         리그, 대회, 친선경기
@@ -100,20 +99,27 @@ public class Match {
     public void setFirstHalfStartTime(LocalTime time) {
         this.firstHalfStartTime = time;
     }
+
     public void setFirstHalfEndTime(LocalTime time) {
         this.firstHalfEndTime = time;
     }
+
     public void setSecondHalfStartTime(LocalTime time) {
         this.secondHalfStartTime = time;
     }
+
     public void setSecondHalfEndTime(LocalTime time) {
         this.secondHalfEndTime = time;
+    }
+
+    public void setMatchState(MatchState state) {
+        this.matchState = state;
     }
 
 
     @Builder
     public Match(String title, Team homeTeam, Team awayTeam, MatchType matchType, String stadium, LocalDate matchDate,
-        LocalTime startTime, LocalTime endTime, LocalTime firstHalfStartTime, LocalTime firstHalfEndTime, LocalTime secondHalfStartTime, LocalTime secondHalfEndTime, String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee, MatchStatus matchStatus) {
+        LocalTime startTime, LocalTime endTime, LocalTime firstHalfStartTime, LocalTime firstHalfEndTime, LocalTime secondHalfStartTime, LocalTime secondHalfEndTime, String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee, MatchState matchState) {
       this.title = title;
       this.homeTeam = homeTeam;
       this.awayTeam = awayTeam;
@@ -130,7 +136,7 @@ public class Match {
       this.assistantReferee1 = assistantReferee1;
       this.assistantReferee2 = assistantReferee2;
       this.fourthReferee = fourthReferee;
-      this.matchStatus = matchStatus;
+      this.matchState = matchState;
     }
 
     @OneToMany(mappedBy = "match",cascade = CascadeType.REMOVE)

--- a/src/main/java/com/matchday/matchdayserver/match/model/enums/MatchState.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/enums/MatchState.java
@@ -1,6 +1,6 @@
 package com.matchday.matchdayserver.match.model.enums;
 
-public enum MatchStatus {
+public enum MatchState {
     SCHEDULED,  // 경기 전
     IN_PLAY,    // 진행 중
     FINISHED

--- a/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
@@ -39,7 +39,7 @@ public class MatchMapper {
           .stadium(match.getStadium())
           .homeScore(scoreResponse.getHomeScore().getGoalCount())
           .awayScore(scoreResponse.getAwayScore().getGoalCount())
-          .matchStatus(match.getMatchStatus())
+          .matchState(match.getMatchState())
           .build();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -104,6 +104,7 @@ public class MatchService {
             validateFirstHalfTime(match, halfTimeRequest);
             if (halfTimeRequest.getStartTime() != null) {
                 match.setFirstHalfStartTime(halfTimeRequest.getStartTime());
+                match.setMatchState(MatchState.IN_PLAY);
             }
             if (halfTimeRequest.getEndTime() != null) {
                 match.setFirstHalfEndTime(halfTimeRequest.getEndTime());
@@ -115,6 +116,7 @@ public class MatchService {
             }
             if (halfTimeRequest.getEndTime() != null) {
                 match.setSecondHalfEndTime(halfTimeRequest.getEndTime());
+                match.setMatchState(MatchState.FINISHED);
             }
         } else {
             throw new ApiException(MatchStatus.INVALID_HALF_TYPE);

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -8,6 +8,7 @@ import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.model.enums.MatchState;
 import com.matchday.matchdayserver.match.model.mapper.MatchMapper;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
 import com.matchday.matchdayserver.match.model.dto.request.MatchMemoRequest;
@@ -98,57 +99,62 @@ public class MatchService {
     public void setHalfTime(Long id, String halfType, MatchHalfTimeRequest halfTimeRequest) {
         Match match = matchRepository.findById(id)
             .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
-        // 전반/후반 구분 처리
-        if ("first".equalsIgnoreCase(halfType)) {
-            LocalTime currentFirstHalfStart = match.getFirstHalfStartTime();
-            LocalTime newFirstHalfStart   = halfTimeRequest.getStartTime();
-            LocalTime newFirstHalfEnd     = halfTimeRequest.getEndTime();
 
-            // 시작 시간만 업데이트하는 경우 종료 시간과의 관계 검증
-            if (newFirstHalfStart != null && match.getFirstHalfEndTime() != null &&
-                newFirstHalfStart.isAfter(match.getFirstHalfEndTime())) {
-                throw new ApiException(MatchStatus.TIME_ORDER_INVALID);
+        if ("first".equalsIgnoreCase(halfType)) {
+            validateFirstHalfTime(match, halfTimeRequest);
+            if (halfTimeRequest.getStartTime() != null) {
+                match.setFirstHalfStartTime(halfTimeRequest.getStartTime());
             }
-            // 종료 시간만 업데이트하는 경우 시작 시간과의 관계 검증
-            if (newFirstHalfEnd != null && currentFirstHalfStart != null &&
-                newFirstHalfEnd.isBefore(currentFirstHalfStart)) {
-                throw new ApiException(MatchStatus.INVALID_TIME_RANGE);
-            }
-            if (newFirstHalfStart != null) {
-                match.setFirstHalfStartTime(newFirstHalfStart);
-            }
-            if (newFirstHalfEnd != null) {
-                match.setFirstHalfEndTime(newFirstHalfEnd);
+            if (halfTimeRequest.getEndTime() != null) {
+                match.setFirstHalfEndTime(halfTimeRequest.getEndTime());
             }
         } else if ("second".equalsIgnoreCase(halfType)) {
-            LocalTime currentSecondHalfStart = match.getSecondHalfStartTime();
-            LocalTime newSecondHalfStart     = halfTimeRequest.getStartTime();
-            LocalTime newSecondHalfEnd       = halfTimeRequest.getEndTime();
-            // 시작 시간만 업데이트하는 경우 종료 시간과의 관계 검증
-            if (newSecondHalfStart != null && match.getSecondHalfEndTime() != null &&
-                newSecondHalfStart.isAfter(match.getSecondHalfEndTime())) {
-                throw new ApiException(MatchStatus.TIME_ORDER_INVALID);
+            validateSecondHalfTime(match, halfTimeRequest);
+            if (halfTimeRequest.getStartTime() != null) {
+                match.setSecondHalfStartTime(halfTimeRequest.getStartTime());
             }
-            // 종료 시간만 업데이트하는 경우 시작 시간과의 관계 검증
-            if (newSecondHalfEnd != null && currentSecondHalfStart != null &&
-                newSecondHalfEnd.isBefore(currentSecondHalfStart)) {
-                throw new ApiException(MatchStatus.INVALID_TIME_RANGE);
-            }
-            // 후반 시작 시간이 전반 종료 시간보다 늦은지 검증
-            if (newSecondHalfStart != null && match.getFirstHalfEndTime() != null &&
-                newSecondHalfStart.isBefore(match.getFirstHalfEndTime())) {
-                throw new ApiException(MatchStatus.SECOND_HALF_TIME_ERROR);
-            }
-            if (newSecondHalfStart != null) {
-                match.setSecondHalfStartTime(newSecondHalfStart);
-            }
-            if (newSecondHalfEnd != null) {
-                match.setSecondHalfEndTime(newSecondHalfEnd);
+            if (halfTimeRequest.getEndTime() != null) {
+                match.setSecondHalfEndTime(halfTimeRequest.getEndTime());
             }
         } else {
             throw new ApiException(MatchStatus.INVALID_HALF_TYPE);
         }
+
         matchRepository.save(match);
     }
 
+    private void validateFirstHalfTime(Match match, MatchHalfTimeRequest request) {
+        LocalTime currentFirstHalfEnd = match.getFirstHalfEndTime();
+        LocalTime currentFirstHalfStart = match.getFirstHalfStartTime();
+        LocalTime newStart = request.getStartTime();
+        LocalTime newEnd = request.getEndTime();
+
+        if (newStart != null && currentFirstHalfEnd != null && newStart.isAfter(currentFirstHalfEnd)) {
+            throw new ApiException(MatchStatus.TIME_ORDER_INVALID);
+        }
+
+        if (newEnd != null && currentFirstHalfStart != null && newEnd.isBefore(currentFirstHalfStart)) {
+            throw new ApiException(MatchStatus.INVALID_TIME_RANGE);
+        }
+    }
+
+    private void validateSecondHalfTime(Match match, MatchHalfTimeRequest request) {
+        LocalTime currentSecondHalfEnd = match.getSecondHalfEndTime();
+        LocalTime currentSecondHalfStart = match.getSecondHalfStartTime();
+        LocalTime newStart = request.getStartTime();
+        LocalTime newEnd = request.getEndTime();
+        LocalTime firstHalfEnd = match.getFirstHalfEndTime();
+
+        if (newStart != null && currentSecondHalfEnd != null && newStart.isAfter(currentSecondHalfEnd)) {
+            throw new ApiException(MatchStatus.TIME_ORDER_INVALID);
+        }
+
+        if (newEnd != null && currentSecondHalfStart != null && newEnd.isBefore(currentSecondHalfStart)) {
+            throw new ApiException(MatchStatus.INVALID_TIME_RANGE);
+        }
+
+        if (newStart != null && firstHalfEnd != null && newStart.isBefore(firstHalfEnd)) {
+            throw new ApiException(MatchStatus.SECOND_HALF_TIME_ERROR);
+        }
+    }
 }


### PR DESCRIPTION
## Related Issue

[MAT-157](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-157)

## Overview
**전반 시작 시간 등록**시 매치 상태(matchState) **진행중(IN_PLAY)**
**후반 종료 시간 등록**시 매치 상태(matchState) **종료(FINISHED)** 로 변경하는 로직 구현 했습니다.

## Screenshot
<img width="734" alt="스크린샷 2025-05-04 오후 11 24 54" src="https://github.com/user-attachments/assets/36fe9a32-c01a-4526-898e-4ec40a3cd762" />

<img width="1119" alt="스크린샷 2025-05-04 오후 11 26 07" src="https://github.com/user-attachments/assets/38d7af59-c66a-4c20-a6bc-1e9fe5af76b4" />

<img width="721" alt="스크린샷 2025-05-04 오후 11 29 01" src="https://github.com/user-attachments/assets/1375b814-c461-4baa-8850-7cc85b8e2c49" />

<img width="1111" alt="스크린샷 2025-05-04 오후 11 29 16" src="https://github.com/user-attachments/assets/8b141304-e6f5-4f09-b95e-cdc6235b31fc" />

[MAT-157]: https://match-day.atlassian.net/browse/MAT-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Match 상태 관련 enum 명칭이 MatchStatus에서 MatchState로 변경되었습니다.
	- Match 및 관련 응답 객체에서 필드명이 matchStatus에서 matchState로 변경되었습니다.
	- Match 엔티티에 matchState를 갱신할 수 있는 setter가 추가되었습니다.
	- MatchService 내 하프타임 관련 유효성 검사가 별도 메서드로 분리되어 코드가 개선되었습니다.
	- 경기 진행 상황에 따라 상태값이 명확히 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->