### PR TITLE
[MAT-163] Global Exception Handler 오류 수정

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
@@ -4,7 +4,7 @@ import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.common.response.DefaultStatus;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.FieldError;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -17,8 +17,9 @@ import java.util.List;
 public class ApiExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
-    public ApiResponse<ApiExceptionInterface> handleApiException(Exception ex, ApiException apiException) {
-        return ApiResponse.error(apiException.getStatus());
+    public ResponseEntity<ApiResponse<ApiExceptionInterface>> handleApiException(Exception ex, ApiException apiException) {
+        return ResponseEntity.status(apiException.getStatus().getHttpStatusCode())
+                .body(ApiResponse.error(apiException.getStatus()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-163

## Overview

- 에러도 http status code 200으로 내려가는 부분 수정
- Validation 누락된 필드 명시될 수 있게 수정

## Screenshot

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/0401c7ad-3a25-4a18-bd23-7650b31a8142" />







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - API 예외 발생 시 반환되는 응답의 HTTP 상태 코드가 상황에 맞게 동적으로 설정됩니다.
  - 유효성 검사 오류 발생 시, 각 필드별로 거부된 값과 상세 메시지가 포함된 에러 목록을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->