### PR TITLE
[MAT-167] User, Team 프로필 이미지 필드 추가 및 저장 로직 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/s3/service/S3PresignedService.java
+++ b/src/main/java/com/matchday/matchdayserver/s3/service/S3PresignedService.java
@@ -9,12 +9,11 @@ import com.matchday.matchdayserver.s3.enums.FileExtension;
 import com.matchday.matchdayserver.s3.enums.FolderType;
 import com.matchday.matchdayserver.team.model.entity.Team;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
-import com.matchday.matchdayserver.team.service.TeamService;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.repository.UserRepository;
-import com.matchday.matchdayserver.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -23,12 +22,11 @@ import java.util.UUID;
 public class S3PresignedService {
 
   private final S3PresignedUrlProvider s3PresignedUrlProvider;
-  private final UserService userService;
-  private final TeamService teamService;
   private final UserRepository userRepository;
   private final TeamRepository teamRepository;
 
     // 업로드 Presigned URL 요청
+    @Transactional
     public S3PresignedResponse generateUploadUrl(String folderName, Long id, String extension) {
         FolderType folderType = FolderType.from(folderName);
 

--- a/src/main/java/com/matchday/matchdayserver/s3/service/S3PresignedService.java
+++ b/src/main/java/com/matchday/matchdayserver/s3/service/S3PresignedService.java
@@ -7,7 +7,11 @@ import com.matchday.matchdayserver.s3.S3PresignedUrlProvider;
 import com.matchday.matchdayserver.s3.dto.S3PresignedResponse;
 import com.matchday.matchdayserver.s3.enums.FileExtension;
 import com.matchday.matchdayserver.s3.enums.FolderType;
+import com.matchday.matchdayserver.team.model.entity.Team;
+import com.matchday.matchdayserver.team.repository.TeamRepository;
 import com.matchday.matchdayserver.team.service.TeamService;
+import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.user.repository.UserRepository;
 import com.matchday.matchdayserver.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,23 +25,39 @@ public class S3PresignedService {
   private final S3PresignedUrlProvider s3PresignedUrlProvider;
   private final UserService userService;
   private final TeamService teamService;
+  private final UserRepository userRepository;
+  private final TeamRepository teamRepository;
 
-  //업로드 Presigned URL 요청
-  public S3PresignedResponse generateUploadUrl(String folderName, Long id, String extension) {
-    // user or team id 유효성 검사
-    validateIdExists(folderName, id);
+    // 업로드 Presigned URL 요청
+    public S3PresignedResponse generateUploadUrl(String folderName, Long id, String extension) {
+        FolderType folderType = FolderType.from(folderName);
 
-    // 파일 확장자 유효성 검사
-    FileExtension fileExtension = FileExtension.from(extension);
+        // 파일 확장자 유효성 검사
+        FileExtension fileExtension = FileExtension.from(extension);
 
-    //파일이름 생성
-    String key = buildKey(folderName, id, extension);
+        // 파일 이름 생성
+        String key = buildKey(folderName, id, extension);
 
-    String uploadUrl = s3PresignedUrlProvider.generateUploadUrl(key, fileExtension.getContentType());
-    return new S3PresignedResponse(uploadUrl, key);
-  }
+        String uploadUrl = s3PresignedUrlProvider.generateUploadUrl(key, fileExtension.getContentType());
 
-  //Read용 Presigned URL 응답
+        switch (folderType) {
+            case USERS -> {
+                User user = userRepository.findById(id)
+                    .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
+                user.updateProfileImg(key);
+                userRepository.save(user);
+            }
+            case TEAMS -> {
+                Team team = teamRepository.findById(id)
+                    .orElseThrow(() -> new ApiException(TeamStatus.NOTFOUND_TEAM));
+                team.updateTeamImg(key);
+                teamRepository.save(team);
+            }
+        }
+        return new S3PresignedResponse(uploadUrl, key);
+    }
+
+    //Read용 Presigned URL 응답
   public S3PresignedResponse generateReadUrl(String folderName, Long id, String key) {
     // user or team id 유효성 검사
     validateIdExists(folderName, id);
@@ -51,22 +71,21 @@ public class S3PresignedService {
 
   //id 유효성 검사
   private void validateIdExists(String folderName, Long id) {
-    FolderType folderType = FolderType.from(folderName);
-    switch (folderType) {
-      case USERS:
-        if (!userService.existsById(id)) {
-          throw new ApiException(UserStatus.NOTFOUND_USER);
-        }
-        break;
-      case TEAMS:
-        if (!teamService.existsById(id)) {
-          throw new ApiException(TeamStatus.NOTFOUND_TEAM);
-        }
-        break;
-    }
+      FolderType folderType = FolderType.from(folderName);
+      boolean exists = switch (folderType) {
+          case USERS -> userRepository.existsById(id);
+          case TEAMS -> teamRepository.existsById(id);
+      };
+      if (!exists) {
+          throw switch (folderType) {
+              case USERS -> new ApiException(UserStatus.NOTFOUND_USER);
+              case TEAMS -> new ApiException(TeamStatus.NOTFOUND_TEAM);
+          };
+      }
   }
 
-  //UUID 생성
+
+    //UUID 생성
   private String createUniqueFileName() {
     return UUID.randomUUID().toString();
   }

--- a/src/main/java/com/matchday/matchdayserver/team/controller/TeamController.java
+++ b/src/main/java/com/matchday/matchdayserver/team/controller/TeamController.java
@@ -26,7 +26,7 @@ public class TeamController {
     private final S3PresignedService s3PresignedManager;
     private static final String FOLDER_NAME = "teams";
 
-    @Operation(summary = "팀 생성", description = "팀 생성 API입니다. <br> 컬러는 모두 Hex Code로 입력 해주세요.")
+    @Operation(summary = "팀 생성", description = "팀 생성 API입니다. <br> 컬러는 모두 Hex Code로 입력 해주세요. <br> teamImg는 선택 사항입니다.")
     @PostMapping
     public ApiResponse<Long> createTeam(@RequestBody @Valid TeamCreateRequest request) {
         Long teamId = teamService.create(request);

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
@@ -23,4 +23,7 @@ public class TeamCreateRequest {
     @Schema(description = "팀 스타킹 컬러", example = "#FFFFFF", required = true)
     @NotBlank(message = "팀 스타킹 컬러는 필수입니다.")
     private String stockingColor; //팀 스타킹 컬러
+
+    @Schema(description = "팀 이미지명", example = "teams/1/597feb0b-0e44-48e6-aefdfdsfdsf.png", required = false)
+    private String teamImg;
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamResponse.java
@@ -11,13 +11,15 @@ public class TeamResponse {
     private String teamColor;
     private String bottomColor;
     private String stockingColor;
+    private String teamImg;
 
     @Builder
-    public TeamResponse(Long id, String name, String teamColor, String bottomColor, String stockingColor) {
+    public TeamResponse(Long id, String name, String teamColor, String bottomColor, String stockingColor, String teamImage) {
         this.id = id;
         this.name = name;
         this.teamColor = teamColor;
         this.bottomColor = bottomColor;
         this.stockingColor = stockingColor;
+        this.teamImg = teamImage;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
@@ -34,16 +34,17 @@ public class Team {
     @Column(nullable = false)
     private String stockingColor; //팀 스타킹 컬러
 
-    @Column(name = "team_img")
+    @Column(name = "team_img", length = 512, nullable = true)
     private String teamImg;
 
 
   @Builder
-    public Team (String name, String teamColor, String bottomColor, String stockingColor) {
+    public Team (String name, String teamColor, String bottomColor, String stockingColor, String teamImg) {
         this.name = name;
         this.teamColor = teamColor;
         this.bottomColor = bottomColor;
         this.stockingColor = stockingColor;
+        this.teamImg = teamImg;
     }
 
     public void updateName(String name) {

--- a/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/entity/Team.java
@@ -34,6 +34,9 @@ public class Team {
     @Column(nullable = false)
     private String stockingColor; //팀 스타킹 컬러
 
+    @Column(name = "team_img")
+    private String teamImg;
+
 
   @Builder
     public Team (String name, String teamColor, String bottomColor, String stockingColor) {
@@ -45,6 +48,10 @@ public class Team {
 
     public void updateName(String name) {
         this.name = name;
+    }
+
+    public void updateTeamImg(String key) {
+        this.teamImg = key;
     }
 
     @OneToMany(mappedBy = "team" , cascade = CascadeType.REMOVE)

--- a/src/main/java/com/matchday/matchdayserver/team/model/mapper/TeamMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/mapper/TeamMapper.java
@@ -16,6 +16,7 @@ public class TeamMapper {
                 .teamColor(team.getTeamColor())
                 .bottomColor(team.getBottomColor())
                 .stockingColor(team.getStockingColor())
+                .teamImage(team.getTeamImg())
                 .build();
     }
 

--- a/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
+++ b/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
@@ -26,7 +26,8 @@ public class TeamService {
     //팀 생성
     public Long create(TeamCreateRequest request){
         validateDuplicateTeamName(request.getName());
-        Team team = new Team(request.getName(), request.getTeamColor(), request.getBottomColor(), request.getStockingColor());
+        Team team = new Team(request.getName(), request.getTeamColor(), request.getBottomColor(), request.getStockingColor(),
+            request.getTeamImg());
         teamRepository.save(team);
         return team.getId();
     }

--- a/src/main/java/com/matchday/matchdayserver/user/controller/UserController.java
+++ b/src/main/java/com/matchday/matchdayserver/user/controller/UserController.java
@@ -22,7 +22,7 @@ public class UserController {
     private final S3PresignedService s3PresignedManager;
     private static final String FOLDER_NAME = "users";
 
-    @Operation(summary = "임시 유저 생성" , description = "생성된 user의 Id 값 반환")
+    @Operation(summary = "임시 유저 생성" , description = "생성된 user의 Id 값 반환 <br> profileImg는 선택 사항입니다.")
     @PostMapping
     public ApiResponse<Long> createUser(@RequestBody UserCreateRequest request) {
         Long userId=userService.createUser(request);

--- a/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserCreateRequest.java
@@ -1,10 +1,16 @@
 package com.matchday.matchdayserver.user.model.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class UserCreateRequest {
+
+    @Schema(description = "유저 이름", example = "홍길동")
     private String name;
+
+    @Schema(description = "유저 프로필 이미지명", example = "users/1/597feb0b-0e44-48e6-aefdfdsfdsf.png", required = false)
+    private String profileImg;
 }

--- a/src/main/java/com/matchday/matchdayserver/user/model/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/dto/response/UserInfoResponse.java
@@ -8,14 +8,16 @@ import java.util.List;
 public class UserInfoResponse {
   private Long userId;
   private String userName;
+  private String profileImg;
   private List<Long> teamIds;
   private List<Long> matchIds;
 
   @Builder
-  public UserInfoResponse(Long userId, String userName ,List<Long> teamIds, List<Long> matchIds) {
+  public UserInfoResponse(Long userId, String userName, String profileImg ,List<Long> teamIds, List<Long> matchIds) {
     this.userId = userId;
     this.userName = userName;
     this.teamIds = teamIds;
     this.matchIds = matchIds;
+    this.profileImg = profileImg;
   }
 }

--- a/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
@@ -20,12 +20,13 @@
         @Column(nullable = false, length = 30)
         private String name;
 
-        @Column(name = "profile_img")
+        @Column(name = "profile_img", length = 512, nullable = true)
         private String profileImg;
 
         @Builder
-        public User (String name) {
+        public User (String name, String profileImg) {
             this.name = name;
+            this.profileImg = profileImg;
         }
 
         public void updateName(String name) {

--- a/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
@@ -20,6 +20,9 @@
         @Column(nullable = false, length = 30)
         private String name;
 
+        @Column(name = "profile_img")
+        private String profileImg;
+
         @Builder
         public User (String name) {
             this.name = name;
@@ -27,6 +30,10 @@
 
         public void updateName(String name) {
             this.name = name;
+        }
+
+        public void updateProfileImg(String key) {
+            this.profileImg = key;
         }
 
         @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)

--- a/src/main/java/com/matchday/matchdayserver/user/model/mapper/UserMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/mapper/UserMapper.java
@@ -12,6 +12,7 @@ public class UserMapper {
         .userName(user.getName())
         .teamIds(teamIds)
         .matchIds(matchIds)
+        .profileImg(user.getProfileImg())
         .build();
   }
 }

--- a/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
+++ b/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
@@ -36,7 +36,7 @@ public class UserService {
 
     public Long createUser(UserCreateRequest request){
         validateDuplicateUser(request.getName());
-        User user = new User(request.getName());
+        User user = new User(request.getName(), request.getProfileImg());
         userRepository.save(user);
         return user.getId();
     }


### PR DESCRIPTION
## Related Issue

[MAT-167](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2/backlog?selectedIssue=MAT-167)

## Overview
- User 및 Team 테이블에 각 프로필 이미지명 저장할 필드 추가
- 프로필 업로드용 url 발급시, DB에 저장하는 로직 추가
- User 및 Team 정보 조회시 각 이미지명 조회 가능하도록 추가

## Screenshot
<img width="721" alt="스크린샷 2025-05-07 오후 8 29 43" src="https://github.com/user-attachments/assets/c4918299-cb16-48a3-a2a7-635c82e483e2" />

<img width="501" alt="스크린샷 2025-05-07 오후 8 30 07" src="https://github.com/user-attachments/assets/49d39292-af31-4975-966c-8e11a59abcb4" />




[MAT-167]: https://match-day.atlassian.net/browse/MAT-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 팀 및 사용자 프로필에 이미지 키(프로필 이미지, 팀 이미지) 저장 기능이 추가되었습니다.
	- 팀 생성 및 사용자 생성 시 이미지 정보 입력이 가능해졌습니다.
	- 팀 및 사용자 정보 조회 시 이미지 정보가 포함되어 반환됩니다.
- **버그 수정**
	- 이미지 업로드 시 팀 또는 사용자 엔티티에 이미지 키가 올바르게 반영되도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->