### PR TITLE
[MAT-164] MatchUser 그리드 좌표 형식 수정

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/controller/MatchUserController.java
@@ -23,7 +23,7 @@ public class MatchUserController {
     @Operation(summary = "매치 유저 등록", description = "{matchID}에 사용자(user)가 등록됩니다.")
     @PostMapping("/{matchId}/users")
     public ApiResponse<Long> createMatch(@PathVariable Long matchId,
-                                           @RequestBody MatchUserCreateRequest request) {
+                                           @RequestBody @Valid MatchUserCreateRequest request) {
         Long id = matchUserService.create(matchId, request);
         return ApiResponse.ok(id);
     }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
@@ -3,6 +3,8 @@ package com.matchday.matchdayserver.matchuser.model.dto;
 import com.matchday.matchdayserver.matchuser.model.enums.MatchUserRole;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 
 @Getter
@@ -20,9 +22,10 @@ public class MatchUserCreateRequest {
     @Schema(description = "매치에서의 포지션", example = "FW")
     private String matchPosition;
 
-    @Schema(description = "매치에서의 선수 그리드 X좌표", example = "1")
-    private int matchGridX;
 
-    @Schema(description = "매치에서의 선수 그리드 Y좌표", example = "2")
-    private int matchGridY;
+    @Min(value = 0, message = "0 이상의 값이어야 합니다.")
+    @Max(value = 29, message = "29 이하의 값이어야 합니다.")
+    @Schema(description = "매치에서의 선수 그리드 좌표(0~29)", example = "1")
+    private Integer matchGrid;
+
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserGridUpdateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserGridUpdateRequest.java
@@ -8,15 +8,9 @@ import lombok.Getter;
 
 @Getter
 public class MatchUserGridUpdateRequest {
-    @NotNull
-    @Min(0)
-    @Max(29)
-    @Schema(description = "그리드 X 좌표", example = "1")
-    private int matchGridX;
+    @Min(value = 0, message = "0이상의 값이어야 합니다.")
+    @Max(value = 29, message = "29 이하의 값이어야 합니다.")
+    @Schema(description = "매치에서의 선수 그리드 좌표", example = "1")
+    private Integer matchGrid;
 
-    @NotNull
-    @Min(0)
-    @Max(29)
-    @Schema(description = "그리드 X 좌표", example = "2")
-    private int matchGridY;
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -22,11 +22,8 @@ public class MatchUserResponse {
     @Schema(description = "매치 포지션", example = "MF")
     private String matchPosition;
 
-    @Schema(description = "선수 그리드 X좌표", example = "1")
-    private int matchGridX;
-
-    @Schema(description = "선수 그리드 Y좌표", example = "2")
-    private int matchGridY;
+    @Schema(description = "선수 그리드 좌표", example = "1")
+    private Integer matchGrid;
 
     @Schema(description = "득점 수", example = "2")
     private Integer goals;
@@ -47,15 +44,14 @@ public class MatchUserResponse {
     private boolean sentOff;
 
     @Builder
-    public MatchUserResponse(Long id, String name, Integer number, String matchPosition, int matchGridX, int matchGridY,
+    public MatchUserResponse(Long id, String name, Integer number, String matchPosition, Integer matchGrid,
         Integer goals, Integer assists,
         Integer yellowCards, Integer redCards, Integer caution, boolean sentOff) {
         this.id = id;
         this.name = name;
         this.number = number;
         this.matchPosition = matchPosition;
-        this.matchGridX = matchGridX;
-        this.matchGridY = matchGridY;
+        this.matchGrid = matchGrid;
         this.goals = goals;
         this.assists = assists;
         this.yellowCards = yellowCards;

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -46,15 +46,10 @@ public class MatchUser {
     @Column(name = "match_position") // 감독 고려하여 null 허용
     private String matchPosition;
 
-    @Min(0)
-    @Max(29)
-    @Column(name = "match_grid_x") // 감독 고려하여 null 허용
-    private Integer matchGridX;
-
-    @Min(0)
-    @Max(29)
-    @Column(name = "match_grid_y") // 감독 고려하여 null 허용
-    private Integer matchGridY;
+    @Min(value = 0)
+    @Max(value = 29)
+    @Column(name = "match_grid") // 감독 고려하여 null 허용
+    private Integer matchGrid;
 
     @OneToMany(mappedBy = "matchUser", cascade = CascadeType.REMOVE)
     private List<MatchEvent> matchEvents;
@@ -63,9 +58,8 @@ public class MatchUser {
         this.matchPosition = matchPosition;
     }
 
-    public void updateMatchGrid(int matchGridX, int matchGridY) {
-        this.matchGridX = matchGridX;
-        this.matchGridY = matchGridY;
+    public void updateMatchGrid(int matchGrid) {
+        this.matchGrid = matchGrid;
     }
 
     public void exchange(MatchUser toMatchUser) {
@@ -73,13 +67,11 @@ public class MatchUser {
             throw new ApiException(MatchStatus.DIFFERENT_TEAM_EXCHANGE);
         }
         String originalPosition = toMatchUser.getMatchPosition();
-        int originalGridX = toMatchUser.getMatchGridX();
-        int originalGridY = toMatchUser.getMatchGridY();
+        int originalGrid = toMatchUser.getMatchGrid();
         toMatchUser.updateMatchPosition(this.matchPosition);
-        toMatchUser.updateMatchGrid(this.matchGridX, this.matchGridY);
+        toMatchUser.updateMatchGrid(this.matchGrid);
 
         this.matchPosition = originalPosition;
-        this.matchGridX = originalGridX;
-        this.matchGridY = originalGridY;
+        this.matchGrid = originalGrid;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/mapper/MatchUserMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/mapper/MatchUserMapper.java
@@ -15,8 +15,7 @@ public class MatchUserMapper {
                 .team(team)
                 .role(request.getRole())
                 .matchPosition(request.getMatchPosition())
-                .matchGridX(request.getMatchGridX())
-                .matchGridY(request.getMatchGridY())
+                .matchGrid(request.getMatchGrid())
                 .build();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -74,7 +74,7 @@ public class MatchUserService {
       MatchUser matchUser = matchUserRepository.findById(matchUserId)
           .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCHUSER));
 
-      matchUser.updateMatchGrid(matchUserGridUpdateRequest.getMatchGridX(), matchUserGridUpdateRequest.getMatchGridY());
+      matchUser.updateMatchGrid(matchUserGridUpdateRequest.getMatchGrid());
      matchUserRepository.save(matchUser);
   }
 
@@ -110,8 +110,7 @@ public class MatchUserService {
                 .name(userName)
                 .number(number)
                 .matchPosition(matchUser.getMatchPosition())
-                .matchGridX(matchUser.getMatchGridX())
-                .matchGridY(matchUser.getMatchGridY())
+                .matchGrid(matchUser.getMatchGrid())
                 .goals(stat.getGoals())
                 .assists(stat.getAssists())
                 .yellowCards(stat.getYellowCards())


### PR DESCRIPTION
## Related Issue
[MAT-164](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-164)

## Overview
- MatchUser 그리드 좌표 형식 리팩토링 (2차원 좌표 -> 0~29 정수)

## Screenshot
<img width="580" alt="스크린샷 2025-05-07 오후 10 05 43" src="https://github.com/user-attachments/assets/8a891d1c-7ee9-4425-a0a3-edd498d279e4" />

<img width="723" alt="스크린샷 2025-05-07 오후 10 03 09" src="https://github.com/user-attachments/assets/1606c615-3132-4471-bfa7-ac57288f64d1" />

<img width="728" alt="스크린샷 2025-05-07 오후 10 04 49" src="https://github.com/user-attachments/assets/c7311ab2-b55b-47a6-8b85-976cedaa8832" />

<img width="519" alt="스크린샷 2025-05-07 오후 10 05 16" src="https://github.com/user-attachments/assets/be850fad-b742-4a4e-a085-e22f57f34587" />






[MAT-164]: https://match-day.atlassian.net/browse/MAT-164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 선수의 그리드 좌표를 기존의 X, Y 값에서 단일 matchGrid 값으로 통합하여 입력 및 조회가 간소화되었습니다.
- **버그 수정**
    - 그리드 값에 대한 유효성 검사가 강화되어 0~29 범위 내에서만 입력할 수 있도록 개선되었습니다.
- **문서화**
    - API 명세서 내 그리드 관련 설명과 예시가 단일 matchGrid 값 기준으로 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->