### PR TITLE
[MAT-166] profileImgUrl 넣기

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -43,10 +43,13 @@ public class MatchUserResponse {
     @Schema(description = "퇴장 여부 (옐로 2장 이상 또는 레드 1장 이상)", example = "false")
     private boolean sentOff;
 
+    @Schema(description = "프로필 이미지 url", example = "users/1/0f3578b1-c4e6-4f6f-2222-567f3f48648a.webp")
+    private String profileImg;
+
     @Builder
     public MatchUserResponse(Long id, String name, Integer number, String matchPosition, Integer matchGrid,
         Integer goals, Integer assists,
-        Integer yellowCards, Integer redCards, Integer caution, boolean sentOff) {
+        Integer yellowCards, Integer redCards, Integer caution, boolean sentOff, String profileImg) {
         this.id = id;
         this.name = name;
         this.number = number;
@@ -58,5 +61,6 @@ public class MatchUserResponse {
         this.redCards = redCards;
         this.caution = caution;
         this.sentOff = sentOff;
+        this.profileImg = profileImg;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -117,6 +117,7 @@ public class MatchUserService {
                 .redCards(stat.getRedCards())
                 .caution(stat.getCaution())
                 .sentOff(stat.isSentOff())  // 퇴장 여부 추가
+                .profileImg(matchUser.getUser().getProfileImg()) // 이미지 url 추가
                 .build();
 
             if (teamId.equals(homeTeamId)) {

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberResponse.java
@@ -12,13 +12,15 @@ public class TeamMemberResponse {
     private Integer number;
     private String defaultPosition;
     private Boolean isActive; //현재 팀에서 활동 여부
+    private String imageUrl; //프로필 이미지 url
 
     @Builder
-    public TeamMemberResponse(Long id, String name, Integer number, String defaultPosition, Boolean isActive) {
+    public TeamMemberResponse(Long id, String name, Integer number, String defaultPosition, Boolean isActive,String imageUrl) {
         this.id = id;
         this.name = name;
         this.number = number;
         this.defaultPosition = defaultPosition;
         this.isActive = isActive;
+        this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/userteam/model/mapper/UserTeamMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/model/mapper/UserTeamMapper.java
@@ -26,6 +26,7 @@ public class UserTeamMapper {
                 .number(userTeam.getNumber())
                 .defaultPosition(userTeam.getDefaultPosition())
                 .isActive(userTeam.getIsActive())
+                .imageUrl(user.getProfileImg())
                 .build();
     }
 }


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-166

## Overview

- 팀에 속한 맴버 리스트 조회 시 profileurl 값이 추가되었습니다
- 매치 참가 선수 목록 조회 시 profileurl 값이 추가되었습니다

## Screenshot

![image](https://github.com/user-attachments/assets/c7faab46-dede-45b1-9d1f-36b76e6ee997)
![image](https://github.com/user-attachments/assets/b920adb0-b9a0-455a-8b49-8ae8a970e69d)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 경기 유저 및 팀 멤버 응답 데이터에 프로필 이미지 URL이 추가되어, 사용자 프로필 이미지를 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->