### PR TITLE
[MAT-170] DTO 스키마 nullable 정보 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -77,7 +77,7 @@ public class MatchController {
         return ApiResponse.ok(matchService.getMatchListByTeam(teamId));
     }
 
-    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> halfType은 전반 `first`, 후반 `second` 입니다.<br>각 시간 단건 등록 가능합니다.")
+    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> halfType은 전반 `first`, 후반 `second` 입니다.<br>각 시간 단건 등록 가능합니다.<br> 전/후반 startTime, endTime 모두 `nullable` 입니다. ")
     @PatchMapping("/{matchId}/{halfType}-time")
     public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @PathVariable String halfType, @RequestBody MatchHalfTimeRequest matchHalfTimeRequest) {
         matchService.setHalfTime(matchId, halfType, matchHalfTimeRequest);

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchCreateRequest.java
@@ -34,16 +34,16 @@ public class MatchCreateRequest {
   @Schema(description = "경기 종료 시간", example = "16:00:00")
   private LocalTime endTime;
 
-  @Schema(description = "주심", example = "주심 이름")
+  @Schema(description = "주심", example = "주심 이름", nullable = true)
   private String mainRefereeName;
 
-  @Schema(description = "부심1", example = "부심1 이름")
+  @Schema(description = "부심1", example = "부심1 이름", nullable = true)
   private String assistantReferee1;
 
-  @Schema(description = "부심2", example = "부심2 이름")
+  @Schema(description = "부심2", example = "부심2 이름", nullable = true)
   private String assistantReferee2;
 
-  @Schema(description = "대기심", example = "대기심 이름")
+  @Schema(description = "대기심", example = "대기심 이름", nullable = true)
     private String fourthReferee;
 
     @Schema(description = "경기 상태 (SCHEDULED, ONGOING, FINISHED)", example = "SCHEDULED")

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
@@ -8,9 +8,9 @@ import java.time.LocalTime;
 @Getter
 @NoArgsConstructor
 public class MatchHalfTimeRequest {
-    @Schema(description = "시작 시간")
+    @Schema(description = "시작 시간", nullable = true)
     private LocalTime startTime;
 
-    @Schema(description = "종료 시간")
+    @Schema(description = "종료 시간", nullable = true)
     private LocalTime endTime;
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchMemoRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchMemoRequest.java
@@ -1,8 +1,10 @@
 package com.matchday.matchdayserver.match.model.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class MatchMemoRequest {
-  private String memo;
+    @Schema(description = "매치 메모", nullable = true)
+    private String memo;
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserCreateRequest.java
@@ -13,19 +13,18 @@ public class MatchUserCreateRequest {
     @Schema(description = "사용자 ID", example = "1")
     private Long userId;
 
-    @Schema(description = "팀 ID", example = "1")
+    @Schema(description = "팀 ID", example = "1", nullable = true)
     private Long teamId;
 
     @Schema(description = "매치에서의 역할", example = "START_PLAYER")
     private MatchUserRole role;
 
-    @Schema(description = "매치에서의 포지션", example = "FW")
+    @Schema(description = "매치에서의 포지션", example = "FW", nullable = true)
     private String matchPosition;
-
 
     @Min(value = 0, message = "0 이상의 값이어야 합니다.")
     @Max(value = 29, message = "29 이하의 값이어야 합니다.")
-    @Schema(description = "매치에서의 선수 그리드 좌표(0~29)", example = "1")
+    @Schema(description = "매치에서의 선수 그리드 좌표(0~29)", example = "1", nullable = true)
     private Integer matchGrid;
 
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/request/TeamCreateRequest.java
@@ -24,6 +24,6 @@ public class TeamCreateRequest {
     @NotBlank(message = "팀 스타킹 컬러는 필수입니다.")
     private String stockingColor; //팀 스타킹 컬러
 
-    @Schema(description = "팀 이미지명", example = "teams/1/597feb0b-0e44-48e6-aefdfdsfdsf.png", required = false)
+    @Schema(description = "팀 이미지명", example = "teams/1/597feb0b-0e44-48e6-aefdfdsfdsf.png", required = false, nullable = true)
     private String teamImg;
 }

--- a/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserCreateRequest.java
@@ -11,6 +11,6 @@ public class UserCreateRequest {
     @Schema(description = "유저 이름", example = "홍길동")
     private String name;
 
-    @Schema(description = "유저 프로필 이미지명", example = "users/1/597feb0b-0e44-48e6-aefdfdsfdsf.png", required = false)
+    @Schema(description = "유저 프로필 이미지명", example = "users/1/597feb0b-0e44-48e6-aefdfdsfdsf.png", required = false, nullable = true)
     private String profileImg;
 }

--- a/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserJoinTeamRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserJoinTeamRequest.java
@@ -10,8 +10,8 @@ public class UserJoinTeamRequest {
 
     @Schema(description = "가입할 팀의 ID", example = "1")
     private Long teamId;
-    @Schema(description = "선수의 등번호", example = "7",nullable = true)
+    @Schema(description = "선수의 등번호", example = "7", nullable = true)
     private Integer number; // 등번호
-    @Schema(description = "선수의 팀 내 포지션", example = "FW",nullable = true)
+    @Schema(description = "선수의 팀 내 포지션", example = "FW", nullable = true)
     private String defaultPosition; // 포지션
 }


### PR DESCRIPTION
## Related Issue
[MAT-170](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-170)

## Overview
각 요청 DTO에 null 허용인 필드에 대해 nullable = true 추가 했습니다.




[MAT-170]: https://match-day.atlassian.net/browse/MAT-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - API 문서에서 여러 필드(예: 심판명, 팀 이미지, 프로필 이미지, 메모, 하프타임 시간 등)가 명시적으로 nullable임을 표시하도록 개선되었습니다.
  - 일부 필드의 Swagger/OpenAPI 설명이 더욱 명확해졌으며, 어노테이션의 포맷이 일관되게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->