### PR TITLE
[MAT-172] 이벤트 전송 필요한 Log만 전송하도록 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
@@ -37,7 +37,7 @@ public class MatchEventMapper {
             .teamName(team.getName())
             .userId(user.getId())
             .userName(user.getName())
-            .eventLog(matchEvent.getEventType().name())
+            .eventLog(matchEvent.getEventType())
             .build();
     }
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventResponse.java
@@ -35,6 +35,6 @@ public class MatchEventResponse {
     @Schema(description = "선수 이름", example = "손흥민")
     private String userName;
 
-    @Schema(description = "이벤트 로그", example = "손흥민 경고", nullable = true)
-    private String eventLog;
+    @Schema(description = "이벤트 로그", example = "손흥민 경고")
+    private MatchEventType eventLog;
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/enums/MatchEventType.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/enums/MatchEventType.java
@@ -38,7 +38,11 @@ public enum MatchEventType {
     RED_CARD("퇴장"),
 
     @Schema(description = "자책골")
-    OWN_GOAL("자책골");
+    OWN_GOAL("자책골"),
+
+    @Schema(description = "경고")
+    WARNING("경고"),
+    ;
 
     public final String value;
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -4,14 +4,11 @@ import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.model.Message;
 import com.matchday.matchdayserver.common.response.DefaultStatus;
 import com.matchday.matchdayserver.common.response.MatchStatus;
-import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.common.response.UserStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
-import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
-import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
-import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
 
 import jakarta.transaction.Transactional;
 
@@ -21,11 +18,8 @@ import java.util.List;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
-import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
 import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
 import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
-import com.matchday.matchdayserver.team.model.entity.Team;
-import com.matchday.matchdayserver.team.repository.TeamRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -51,8 +45,17 @@ public class MatchEventSaveService {
         List<MatchEventResponse> matchEventResponse = matchEventStrategy
             .generateMatchEventLog(request.getData(), match, matchUser);
         for (MatchEventResponse response : matchEventResponse) {
+            if (!neededToSendEvent(response.getEventLog())) continue;
             messagingTemplate.convertAndSend("/topic/match/" + matchId, response);
         }
+    }
+
+    private boolean neededToSendEvent(MatchEventType matchEventType) {
+        return MatchEventType.GOAL.equals(matchEventType)
+            || MatchEventType.OFFSIDE.equals(matchEventType)
+            || MatchEventType.YELLOW_CARD.equals(matchEventType)
+            || MatchEventType.RED_CARD.equals(matchEventType)
+            || MatchEventType.VALID_SHOT.equals(matchEventType);
     }
 
     private void validateAuthUser(Long matchId, String token) {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -55,7 +55,9 @@ public class MatchEventSaveService {
             || MatchEventType.OFFSIDE.equals(matchEventType)
             || MatchEventType.YELLOW_CARD.equals(matchEventType)
             || MatchEventType.RED_CARD.equals(matchEventType)
-            || MatchEventType.VALID_SHOT.equals(matchEventType);
+            || MatchEventType.SUB_IN.equals(matchEventType)
+            || MatchEventType.SUB_OUT.equals(matchEventType)
+            ;
     }
 
     private void validateAuthUser(Long matchId, String token) {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
@@ -112,7 +112,7 @@ public class MatchEventStrategy {
     /**
      * 카드(옐로카드/레드카드) 이벤트 기록 시 호출됩니다.
      * <ul>
-     * <li>카드 이벤트(offsideEvent)를 생성합니다.</li>
+     * <li>카드 이벤트(cardEvent)를 생성합니다.</li>
      * <li>카드 이벤트를 기반으로 경고(warningEvent), 파울(foulEvent) 이벤트를 각각 복사 생성합니다.</li>
      * <li>세 이벤트를 모두 저장하고, 각각의 응답 객체를 반환합니다.</li>
      * </ul>
@@ -124,12 +124,12 @@ public class MatchEventStrategy {
      */
     private List<MatchEventResponse> generateCardEvent(MatchEventRequest request, Match match,
         MatchUser matchUser) {
-        MatchEvent offsideEvent = MatchEventMapper.toEntity(request, match, matchUser);
-        MatchEvent warningEvent = offsideEvent.copyWith(MatchEventType.WARNING);
-        MatchEvent foulEvent = offsideEvent.copyWith(MatchEventType.FOUL);
-        matchEventRepository.saveAll(List.of(offsideEvent, warningEvent, foulEvent));
+        MatchEvent cardEvent = MatchEventMapper.toEntity(request, match, matchUser);
+        MatchEvent warningEvent = cardEvent.copyWith(MatchEventType.WARNING);
+        MatchEvent foulEvent = cardEvent.copyWith(MatchEventType.FOUL);
+        matchEventRepository.saveAll(List.of(cardEvent, warningEvent, foulEvent));
         return List.of(
-            MatchEventMapper.toResponse(offsideEvent),
+            MatchEventMapper.toResponse(cardEvent),
             MatchEventMapper.toResponse(warningEvent),
             MatchEventMapper.toResponse(foulEvent));
     }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
@@ -25,6 +25,7 @@ import lombok.RequiredArgsConstructor;
  * <li>골 기록 시: 유효슛, 슛 이벤트를 함께 생성</li>
  * <li>오프사이드 기록 시: 오프사이드, 파울 이벤트를 함께 생성</li>
  * <li>유효슛 기록 시: 유효슛, 슛 이벤트를 함께 생성</li>
+ * <li>경고(옐로 카드, 레드 카드): 파울</li>
  * </ul>
  * <p>
  * 트랜잭션 처리는 상위 서비스에서 담당해야 합니다.
@@ -47,6 +48,9 @@ public class MatchEventStrategy {
                 return generateGoalEvent(request, match, matchUser);
             case OFFSIDE:
                 return generateOffsideEvent(request, match, matchUser);
+            case YELLOW_CARD:
+            case RED_CARD:
+                return generateCardEvent(request, match, matchUser);
             case VALID_SHOT:
                 return generateValidShotEvent(request, match, matchUser);
             default:
@@ -102,6 +106,31 @@ public class MatchEventStrategy {
         matchEventRepository.saveAll(List.of(offsideEvent, foulEvent));
         return List.of(
             MatchEventMapper.toResponse(offsideEvent),
+            MatchEventMapper.toResponse(foulEvent));
+    }
+
+    /**
+     * 카드(옐로카드/레드카드) 이벤트 기록 시 호출됩니다.
+     * <ul>
+     * <li>카드 이벤트(offsideEvent)를 생성합니다.</li>
+     * <li>카드 이벤트를 기반으로 경고(warningEvent), 파울(foulEvent) 이벤트를 각각 복사 생성합니다.</li>
+     * <li>세 이벤트를 모두 저장하고, 각각의 응답 객체를 반환합니다.</li>
+     * </ul>
+     *
+     * @param request   카드 이벤트 요청 정보
+     * @param match     해당 경기 정보
+     * @param matchUser 이벤트를 기록한 사용자
+     * @return 생성된 이벤트들의 응답 리스트 (카드, 경고, 파울)
+     */
+    private List<MatchEventResponse> generateCardEvent(MatchEventRequest request, Match match,
+        MatchUser matchUser) {
+        MatchEvent offsideEvent = MatchEventMapper.toEntity(request, match, matchUser);
+        MatchEvent warningEvent = offsideEvent.copyWith(MatchEventType.WARNING);
+        MatchEvent foulEvent = offsideEvent.copyWith(MatchEventType.FOUL);
+        matchEventRepository.saveAll(List.of(offsideEvent, warningEvent, foulEvent));
+        return List.of(
+            MatchEventMapper.toResponse(offsideEvent),
+            MatchEventMapper.toResponse(warningEvent),
             MatchEventMapper.toResponse(foulEvent));
     }
 


### PR DESCRIPTION
## Related Issue

Related to : 해당 커밋에 관련된 이슈 번호

## Overview

- 이벤트 전송 필요한 Log만 전송하도록 변경(골, 오프사이드, 카드, 교체)
- MatchEventType에 경고 추가 
- Card 이벤트 발생시 경고 파울 증가 

## Screenshot

- 파울, 경고는 로그 발생 X

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/69d26299-dc94-4676-a755-dac419199600" />

- 기록은 오름

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/e40f8baa-9ded-4c6d-92fb-e45aec55cf79" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 경기 이벤트 유형에 "경고"가 추가되었습니다.
	- 옐로우/레드 카드 발생 시 경고 및 파울 이벤트가 함께 생성됩니다.
	- 경기 참가자 정보에 교체(교체입장, 교체퇴장) 상태가 추가되어 확인할 수 있습니다.
- **버그 수정**
	- 메시지 전송 시 골, 오프사이드, 카드, 교체 등 주요 이벤트만 실시간 알림으로 전송되도록 개선되었습니다.
- **스타일/리팩터**
	- 이벤트 응답에서 eventLog 필드가 문자열에서 이벤트 타입(enum)으로 변경되어 타입 안정성이 향상되었습니다.
	- 경기 및 매치 관련 시간 필드명이 startTime/endTime에서 plannedStartTime/plannedEndTime으로 변경되어 의미가 명확해졌습니다.
	- 여러 응답 객체 및 요청 DTO에 대해 필수값 검증(@NotNull)과 API 문서용 어노테이션(@Schema)이 추가되어 안정성과 문서화가 강화되었습니다.
	- 프로필 등록/조회 URL 응답에서 파일명 필드가 제거되어 단순화되었습니다.
- **문서**
	- 일부 API 문서 설명이 보완되어 기능 이해도가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->