### PR TITLE
[MAT-180] MatchUserResponse 교체인/아웃 여부에 대한 필드 추가 

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -1,6 +1,7 @@
 package com.matchday.matchdayserver.matchevent.repository;
 
 import com.matchday.matchdayserver.matchevent.model.dto.EventTypeCount;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.matchday.matchdayserver.matchevent.model.entity.MatchEvent;
@@ -35,4 +36,6 @@ public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
         @Param("matchUserId") Long matchUserId,
         @Param("matchId") Long matchId
     );
+
+    boolean existsByMatchUserIdAndEventType(Long matchUserId, MatchEventType eventType);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -46,10 +46,16 @@ public class MatchUserResponse {
     @Schema(description = "프로필 이미지 url", example = "users/1/0f3578b1-c4e6-4f6f-2222-567f3f48648a.webp")
     private String profileImg;
 
+    @Schema(description = "교체인 여부", example = "true")
+    private boolean subIn;
+
+    @Schema(description = "교체아웃 여부", example = "false")
+    private boolean subOut;
+
     @Builder
     public MatchUserResponse(Long id, String name, Integer number, String matchPosition, Integer matchGrid,
         Integer goals, Integer assists,
-        Integer yellowCards, Integer redCards, Integer caution, boolean sentOff, String profileImg) {
+        Integer yellowCards, Integer redCards, Integer caution, boolean sentOff, String profileImg,boolean subIn, boolean subOut) {
         this.id = id;
         this.name = name;
         this.number = number;
@@ -62,5 +68,7 @@ public class MatchUserResponse {
         this.caution = caution;
         this.sentOff = sentOff;
         this.profileImg = profileImg;
+        this.subIn = subIn;
+        this.subOut = subOut;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -7,6 +7,8 @@ import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.common.response.UserStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
+import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
 import com.matchday.matchdayserver.matchevent.service.MatchEventQueryService;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserCreateRequest;
 import com.matchday.matchdayserver.matchuser.model.dto.MatchUserEventStat;
@@ -41,6 +43,7 @@ public class MatchUserService {
   private final TeamRepository teamRepository;
   private final MatchEventQueryService matchEventQueryService;
   private final UserTeamRepository userTeamRepository;
+  private final MatchEventRepository matchEventRepository;
 
   @Transactional
   public Long create(Long matchId, MatchUserCreateRequest request) {
@@ -105,6 +108,9 @@ public class MatchUserService {
 
             MatchUserEventStat stat = matchEventQueryService.getMatchUserEventStat(matchId, matchUser.getId());
 
+            boolean subIn = matchEventRepository.existsByMatchUserIdAndEventType(matchUser.getId(), MatchEventType.SUB_IN);
+            boolean subOut = matchEventRepository.existsByMatchUserIdAndEventType(matchUser.getId(), MatchEventType.SUB_OUT);
+
             MatchUserResponse response = MatchUserResponse.builder()
                 .id(userId)
                 .name(userName)
@@ -118,6 +124,8 @@ public class MatchUserService {
                 .caution(stat.getCaution())
                 .sentOff(stat.isSentOff())  // 퇴장 여부 추가
                 .profileImg(matchUser.getUser().getProfileImg()) // 이미지 url 추가
+                .subIn(subIn)
+                .subOut(subOut)
                 .build();
 
             if (teamId.equals(homeTeamId)) {


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-180

## Overview

- MatchUserResponse 교체인/아웃 여부에 대한 필드 추가

## Screenshot

![image](https://github.com/user-attachments/assets/b0c0107e-bbe9-421b-869e-3ce631f5ef57)






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 각 경기 사용자에 대해 교체 투입(subIn) 및 교체 아웃(subOut) 여부가 응답에 포함됩니다.
- **문서화**
    - 교체 투입 및 교체 아웃 상태에 대한 Swagger 설명과 예시가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->