### PR TITLE
[MAT-186] 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //p6spy
-    implementation 'p6spy:p6spy:3.9.1'
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -21,7 +21,7 @@ public class MatchEventQueryService {
     public MatchUserEventStat getMatchUserEventStat(Long matchId, Long matchUserId) {
         int goals = 0, assists = 0, yellowCards = 0, redCards = 0;
 
-        List<EventTypeCount> counts = matchEventRepository.countEventTypesByMatchUserAndMatch(matchId, matchUserId);
+        List<EventTypeCount> counts = matchEventRepository.countEventTypesByMatchUserAndMatch(matchUserId, matchId);
         for (EventTypeCount c : counts) {
             switch (c.getEventType()) {
                 case "GOALS" -> goals = c.getCount().intValue();

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -52,6 +52,7 @@ public class MatchEventSaveService {
 
     private boolean neededToSendEvent(MatchEventType matchEventType) {
         return MatchEventType.GOAL.equals(matchEventType)
+            || MatchEventType.ASSIST.equals(matchEventType)
             || MatchEventType.OFFSIDE.equals(matchEventType)
             || MatchEventType.YELLOW_CARD.equals(matchEventType)
             || MatchEventType.RED_CARD.equals(matchEventType)

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -22,5 +22,5 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
   @Query("SELECT mu.match.id FROM MatchUser mu WHERE mu.user.id = :userId")
   List<Long> findMatchIdsByUserId(@Param("userId") Long userId);
 
-  List<MatchUser> findByMatchId(Long matchId);
+  List<MatchUser> findByMatchIdAndTeamIdIsNotNull(Long matchId);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -83,7 +83,7 @@ public class MatchUserService {
 
     @Transactional
     public MatchUserGroupResponse getGroupedMatchUsers(Long matchId) {
-        List<MatchUser> matchUsers = matchUserRepository.findByMatchId(matchId);
+        List<MatchUser> matchUsers = matchUserRepository.findByMatchIdAndTeamIdIsNotNull(matchId);
         Match match = matchRepository.findById(matchId)
             .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
         Long homeTeamId = match.getHomeTeam().getId();

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,8 @@
+decorator:
+    datasource:
+        p6spy:
+            enable-logging: true
+            multiline: true
+            logging: slf4j
+            # 실제값 한 줄만 출력됨 이거 안하면 ? 쿼리하는 거까지 총 두 줄뜸
+            log-format: "%(sql)"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,9 +14,7 @@ spring:
             ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
         properties:
             hibernate:
-                format_sql: true
                 dialect: org.hibernate.dialect.MySQLDialect
-        show-sql: true
 
     sql:
         init:
@@ -37,3 +35,8 @@ spring:
 springdoc:
     api-docs:
         version: "openapi_3_0"
+
+decorator:
+    datasource:
+        p6spy:
+            enable-logging: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,39 +1,39 @@
 spring:
-  config:
-    import: optional:file:.env[.properties]
-  application:
-    name: matchday-server
-  datasource:
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    config:
+        import: optional:file:.env[.properties]
+    application:
+        name: matchday-server
+    datasource:
+        url: ${SPRING_DATASOURCE_URL}
+        username: ${SPRING_DATASOURCE_USERNAME}
+        password: ${SPRING_DATASOURCE_PASSWORD}
+        driver-class-name: com.mysql.cj.jdbc.Driver
 
-  jpa:
-    hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
-    properties:
-      hibernate:
-        format_sql: true
-        dialect: org.hibernate.dialect.MySQLDialect
-    show-sql: true
+    jpa:
+        hibernate:
+            ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO}
+        properties:
+            hibernate:
+                format_sql: true
+                dialect: org.hibernate.dialect.MySQLDialect
+        show-sql: true
 
-  sql:
-    init:
-      mode: always
+    sql:
+        init:
+            mode: always
 
-  cloud:
-    aws:
-      s3:
-        bucket: ${BUCKET_NAME}
-      stack:
-        auto: false
-      region:
-        static: ${AWS_REGION}
-      credentials:
-        access-key: ${AWS_ACCESS_KEY}
-        secret-key: ${AWS_SECRET_KEY}
+    cloud:
+        aws:
+            s3:
+                bucket: ${BUCKET_NAME}
+            stack:
+                auto: false
+            region:
+                static: ${AWS_REGION}
+            credentials:
+                access-key: ${AWS_ACCESS_KEY}
+                secret-key: ${AWS_SECRET_KEY}
 
 springdoc:
-  api-docs:
-    version: "openapi_3_0"
+    api-docs:
+        version: "openapi_3_0"


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-186

## Overview

- dev profile에서만 sql 로그 보이도록 수정
- 각 선수별 점수 조회 안되던 버그 수정 (파라미터 순서 변경)

## Screenshot

- 버그 수정 결과 

<img width="75%" alt="image" src="https://github.com/user-attachments/assets/8d084ba3-5177-4079-b709-2ed8a6d4b2a2" />

- intellij dev profile 설정 방법

<img width="75%" alt="image" src="https://github.com/user-attachments/assets/92407979-1c85-4da0-8c1a-d227f9c8df58" />








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - ASSIST 이벤트 유형이 실시간 메시지 전송 대상에 추가되었습니다.

- **버그 수정**
    - 매치 유저 조회 시 팀이 지정된 유저만 반환되도록 개선되었습니다.

- **환경설정**
    - p6spy 의존성이 Spring Boot Starter로 교체되어 SQL 로그 설정이 개선되었습니다.
    - 개발 및 운영 환경에서 SQL 로깅 관련 설정이 추가 및 정비되었습니다.

- **스타일**
    - 설정 파일의 들여쓰기가 일관성 있게 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->