### PR TITLE
[MAT-187] 팀 ID로 Event 기록하는 End Point 추가 

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
@@ -51,10 +51,11 @@ public class MatchCreateService {
                 .fourthReferee(request.getFourthReferee())
                 .matchState(request.getMatchState())
                 .build();
+        matchRepository.save(match);
+
         // Team 기록용 임시 유저 생성
         createTempMatchUsers(match, List.of(homeTeam, awayTeam));
 
-        matchRepository.save(match);
         return match.getId();
     }
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventWebSocketController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventWebSocketController.java
@@ -14,10 +14,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MatchEventWebSocketController {
 
-  private final MatchEventSaveService matchEventSaveService;
+    private final MatchEventSaveService matchEventSaveService;
 
-  @MessageMapping("/match/{matchId}")
-  public void recordEvent(@DestinationVariable Long matchId, Message<MatchEventRequest> matchEventRequest) {
-    matchEventSaveService.saveMatchEvent(matchId, matchEventRequest);
-  }
+    @MessageMapping("/match/{matchId}")
+    public void recordEvent(@DestinationVariable Long matchId,
+        Message<MatchEventRequest> matchEventRequest) {
+        matchEventSaveService.saveMatchEvent(matchId, matchEventRequest);
+    }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventWebSocketController.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/controller/MatchEventWebSocketController.java
@@ -1,11 +1,12 @@
 package com.matchday.matchdayserver.matchevent.controller;
 
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventUserRequest;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
 
 import com.matchday.matchdayserver.common.model.Message;
-import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
 import com.matchday.matchdayserver.matchevent.service.MatchEventSaveService;
 
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,17 @@ public class MatchEventWebSocketController {
 
     @MessageMapping("/match/{matchId}")
     public void recordEvent(@DestinationVariable Long matchId,
-        Message<MatchEventRequest> matchEventRequest) {
+        Message<MatchEventUserRequest> matchEventRequest) {
+
         matchEventSaveService.saveMatchEvent(matchId, matchEventRequest);
+    }
+
+    @MessageMapping("/match/{matchId}/teams/{teamId}")
+    public void recordTeamEvent(
+        @DestinationVariable Long matchId,
+        @DestinationVariable Long teamId,
+        Message<MatchEventRequest> matchEventRequest) {
+
+        matchEventSaveService.saveMatchTeamEvent(matchId, teamId, matchEventRequest);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/mapper/MatchEventMapper.java
@@ -10,6 +10,7 @@ import com.matchday.matchdayserver.user.model.entity.User;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public class MatchEventMapper {
 
@@ -27,7 +28,7 @@ public class MatchEventMapper {
         Long elapsedMinutes = calculateElapsedMinutes(
             match.getPlannedStartTime().atDate(match.getMatchDate()),
             matchEvent.getEventTime());
-        User user = matchEvent.getMatchUser().getUser();
+        User user = Optional.ofNullable(matchEvent.getMatchUser().getUser()).orElseGet(User::mock);
         Team team = matchEvent.getMatchUser().getTeam();
 
         return MatchEventResponse.builder()

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventRequest.java
@@ -16,10 +16,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MatchEventRequest {
     @NotNull
-    @Schema(description = "이벤트 유저", example = "1")
-    private Long userId;
-
-    @NotNull
     @Schema(description = "이벤트 타입", example = "GOAL")
     private MatchEventType eventType;
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventUserRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/MatchEventUserRequest.java
@@ -1,0 +1,18 @@
+package com.matchday.matchdayserver.matchevent.model.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "경기 이벤트 유저 요청 DTO")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MatchEventUserRequest extends MatchEventRequest {
+    @NotNull
+    @Schema(description = "이벤트 유저", example = "1")
+    private Long userId;
+}

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -8,6 +8,7 @@ import com.matchday.matchdayserver.common.response.UserStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
+import com.matchday.matchdayserver.matchevent.model.dto.MatchEventUserRequest;
 import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
 
 import jakarta.transaction.Transactional;
@@ -32,7 +33,7 @@ public class MatchEventSaveService {
     private final SimpMessagingTemplate messagingTemplate;
     private final MatchEventStrategy matchEventStrategy;
 
-    public void saveMatchEvent(Long matchId, Message<MatchEventRequest> request) {
+    public void saveMatchEvent(Long matchId, Message<MatchEventUserRequest> request) {
         validateRequest(matchId, request);
         validateAuthUser(matchId, request.getToken());
 
@@ -65,7 +66,7 @@ public class MatchEventSaveService {
         Long authId = Long.parseLong(token);
 
         MatchUser authUser = matchUserRepository
-            .findByMatchIdAndUserIdWithFetch(matchId, authId)
+            .findById(authId)
             .orElseThrow(() -> new ApiException(UserStatus.NOTFOUND_USER));
 
         if (!authUser.getMatch().getId().equals(matchId)) {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -74,7 +74,7 @@ public class MatchEventSaveService {
         }
     }
 
-    private void validateRequest(Long matchId, Message<MatchEventRequest> request) {
+    private void validateRequest(Long matchId, Message<MatchEventUserRequest> request) {
         List<String> errorMessages = new ArrayList<>();
 
         if (request.getData().getUserId() == null) {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -52,7 +52,7 @@ public class MatchEventSaveService {
     }
 
     public void saveMatchTeamEvent(Long matchId, Long teamId, Message<MatchEventRequest> request) {
-        validateAuthUser(teamId, request.getToken());
+        validateAuthUser(matchId, request.getToken());
 
         // 임시 유저
         MatchUser matchUser = matchUserRepository
@@ -97,6 +97,10 @@ public class MatchEventSaveService {
 
         if (request.getData().getUserId() == null) {
             errorMessages.add("userId는 필수 입력 값입니다.");
+        }
+
+        if(matchId == null) {
+            errorMessages.add("matchId는 필수 입력 값입니다.");
         }
 
         if (errorMessages.size() > 0) {

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -32,8 +32,8 @@ public class MatchUser {
     private Match match;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
-    private User user;
+    @JoinColumn(name = "user_id")
+    private User user; // user id null일 경우 임시 유저
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -12,8 +12,15 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
   @Query("SELECT mu FROM MatchUser mu " +
       "JOIN FETCH mu.match m " +
       "JOIN FETCH mu.user u " +
+      "JOIN FETCH mu.team t " +
       "WHERE mu.match.id = :matchId AND mu.user.id = :userId")
   Optional<MatchUser> findByMatchIdAndUserIdWithFetch(@Param("matchId") Long matchId, @Param("userId") Long userId);
+
+  @Query("SELECT mu FROM MatchUser mu " +
+      "JOIN FETCH mu.match m " +
+      "JOIN FETCH mu.team t " +
+      "WHERE mu.match.id = :matchId AND mu.team.id = :teamId AND mu.user.id IS NULL")
+  Optional<MatchUser> findTempUser(@Param("matchId") Long matchId, @Param("teamId") Long teamId);
 
   //특정 매치에 특정 유저가 존재하는지 여부
   boolean existsByMatchIdAndUserId(Long matchId, Long userId);

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -22,5 +22,10 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
   @Query("SELECT mu.match.id FROM MatchUser mu WHERE mu.user.id = :userId")
   List<Long> findMatchIdsByUserId(@Param("userId") Long userId);
 
-  List<MatchUser> findByMatchIdAndTeamIdIsNotNull(Long matchId);
+  /**
+   * 감독/기록관 제외, 임시 유저 제외
+   * @param matchId
+   * @return
+  */
+  List<MatchUser> findByMatchIdAndTeamIdIsNotNullAndUserIdIsNotNull(Long matchId);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -83,7 +83,7 @@ public class MatchUserService {
 
     @Transactional
     public MatchUserGroupResponse getGroupedMatchUsers(Long matchId) {
-        List<MatchUser> matchUsers = matchUserRepository.findByMatchIdAndTeamIdIsNotNull(matchId);
+        List<MatchUser> matchUsers = matchUserRepository.findByMatchIdAndTeamIdIsNotNullAndUserIdIsNotNull(matchId);
         Match match = matchRepository.findById(matchId)
             .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
         Long homeTeamId = match.getHomeTeam().getId();

--- a/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/entity/User.java
@@ -39,4 +39,10 @@
 
         @OneToMany(mappedBy = "user",cascade = CascadeType.REMOVE)
         private List<UserTeam> userTeams;
+
+        public static User mock() {
+            return User.builder()
+                    .name("UNKNOWN")
+                    .build();
+        }
     }


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-187

🚨 머지시 DB에 MatchUser.userId에 nullable로 변경 필요

## Review Request 

- userId가 nullable이 되면 오류가 발생할 수 있는 부분들을 미리 수정해놨지만 다 수정이 됐을지 모르겠습니다. 
- 혹시 생각나는 부분 있으면 수정 부탁드립니다. 🙏🙏🙏

## Overview

- 각 MatchUser의 역할에 따라 (임시 유저, 기록관, 감독) 발생할 수 있는 Bug 미연에 방지
- teamId로 경기 이벤트 기록할 수 있는 end point 구현

## Screenshot

- 팀 id로 event 기록

<img width="100%" alt="image" src="https://github.com/user-attachments/assets/ef501a5a-919f-423c-837e-1e397c9d8b9e" />

- 선수 목록 조회시에 임시 유저는 뜨지 않음

```json
{
  "status": 200,
  "data": {
    "homeTeam": {
      "starters": [
        {
          "id": 1,
          "name": "3af",
          "number": 7,
          "matchPosition": "FW",
          "matchGrid": 1,
          "goals": 0,
          "assists": 0,
          "yellowCards": 0,
          "redCards": 0,
          "caution": 0,
          "sentOff": false,
          "profileImg": null,
          "subIn": false,
          "subOut": false
        }
      ],
      "substitutes": []
    },
    "awayTeam": {
      "starters": [
        {
          "id": 2,
          "name": "104",
          "number": 7,
          "matchPosition": "FW",
          "matchGrid": 1,
          "goals": 0,
          "assists": 0,
          "yellowCards": 0,
          "redCards": 0,
          "caution": 0,
          "sentOff": false,
          "profileImg": null,
          "subIn": false,
          "subOut": false
        }
      ],
      "substitutes": []
    }
  },
  "message": "OK"
}
```

- match score 조회시에는 뜸

```json
{
  "status": 200,
  "data": {
    "matchId": 1,
    "homeTeamId": 1,
    "awayTeamId": 2,
    "homeScore": {
      "goalCount": 14,
      "shotCount": 14,
      "validShotCount": 14,
      "cornerKickCount": 0,
      "offsideCount": 0,
      "foulCount": 0,
      "warningCount": 0
    },
    "awayScore": {
      "goalCount": 0,
      "shotCount": 0,
      "validShotCount": 0,
      "cornerKickCount": 0,
      "offsideCount": 0,
      "foulCount": 0,
      "warningCount": 0
    }
  },
  "message": "OK"
}
```







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 경기 생성 시 임시 선수(임시 MatchUser)가 자동으로 생성되어 팀별로 할당됩니다.
    - 팀 단위의 경기 이벤트 기록 기능이 추가되었습니다.

- **버그 수정**
    - 사용자 정보가 없는 경우에도 이벤트 응답에서 기본 사용자 정보("UNKNOWN")가 제공됩니다.

- **변경 사항**
    - 경기 이벤트 요청 구조가 변경되어, 사용자 ID가 별도 객체로 분리되었습니다.
    - 임시 선수(사용자 정보 없음)와 실제 선수를 구분하여 조회 및 그룹화가 이뤄집니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->