### PR TITLE
[MAT-189] OWN_GOAL도 점수 집계에 반영되도록 수정

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
@@ -44,6 +44,17 @@ public class MatchScoreResponse {
     }
 
     public void updateScore(Long teamId, MatchEventType eventType) {
+        // 자책골인 경우
+        if (eventType == MatchEventType.OWN_GOAL) {
+            if (teamId.equals(this.homeTeamId)) {
+                updateScore(awayScore, MatchEventType.GOAL); // homeTeam이 자책골 기록시 awayTeam의 골
+            } else if (teamId.equals(this.awayTeamId)) {
+                updateScore(homeScore, MatchEventType.GOAL); // awayTeam이 자책골 기록시 homeTeam의 골
+            } else {
+                throw new ApiException(MatchStatus.NOTFOUND_TEAM);
+            }
+            return;
+        }
         if (teamId.equals(this.homeTeamId)) {
             updateScore(homeScore, eventType);
         } else if (teamId.equals(this.awayTeamId)) {


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-189

## Overview

- MatchScoreResponse 내부 updateScore 메소드 로직을 수정하여 OWN_GOAL도 점수 집계에 반영되도록 하였습니다






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 자책골 발생 시 상대 팀의 점수가 올바르게 증가하도록 점수 업데이트 로직을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->