### PR TITLE
[MAT-195]  매치 점수 조회 response에 ownGoalCount 필드 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
@@ -74,6 +74,7 @@ public class MatchScoreResponse {
             case OFFSIDE -> score.upOffsideCount();
             case YELLOW_CARD -> score.upWarningCount();
             case RED_CARD -> score.upWarningCount();
+            case OWN_GOAL -> score.upOwnGoalCount();
         }
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
@@ -48,8 +48,10 @@ public class MatchScoreResponse {
         if (eventType == MatchEventType.OWN_GOAL) {
             if (teamId.equals(this.homeTeamId)) {
                 updateScore(awayScore, MatchEventType.GOAL); // homeTeam이 자책골 기록시 awayTeam의 골
+                updateScore(homeScore, eventType); //homeTeam의 자책골 +1
             } else if (teamId.equals(this.awayTeamId)) {
                 updateScore(homeScore, MatchEventType.GOAL); // awayTeam이 자책골 기록시 homeTeam의 골
+                updateScore(awayScore, eventType);  //awayTeam의 자책골 +1
             } else {
                 throw new ApiException(MatchStatus.NOTFOUND_TEAM);
             }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/ScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/ScoreResponse.java
@@ -43,6 +43,10 @@ public class ScoreResponse {
     @Schema(description = "경고 횟수", example = "2")
     private int warningCount;
 
+    @NotNull
+    @Schema(description = "자책골 횟수", example = "1")
+    private int ownGoalCount;
+
   public void upGoalCount() {
     this.goalCount++;
   }
@@ -71,6 +75,10 @@ public class ScoreResponse {
     this.warningCount++;
   }
 
+  public void upOwnGoalCount() {
+      this.ownGoalCount++;
+  }
+
   public static ScoreResponse defaultScore() {
     return ScoreResponse.builder()
         .goalCount(0)
@@ -80,6 +88,7 @@ public class ScoreResponse {
         .offsideCount(0)
         .foulCount(0)
         .warningCount(0)
+        .ownGoalCount(0)
         .build();
   }
 }


### PR DESCRIPTION
## Related Issue

[MAT-195](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2/backlog?selectedIssue=MAT-195)

## Overview
- 매치 점수 조회시 자책골(ownGoalCount) 조회 되도록 응답 필드 추가 했습니다.
- 자책골 발생시 발생 시킨 팀의 upOwnGoalCount 되도록 추가 했습니다.

## Screenshot
<img width="499" alt="스크린샷 2025-05-13 오후 4 01 54" src="https://github.com/user-attachments/assets/fd6425f0-29b9-4c90-8461-027274b951e3" />






[MAT-195]: https://match-day.atlassian.net/browse/MAT-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 팀별 자책골 수를 별도로 집계하여 표시하는 기능이 추가되었습니다.

- **버그 수정**
  - 자책골 발생 시, 득점 팀의 자책골 카운트가 올바르게 증가하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->