### PR TITLE
[MAT-174] 매치 경기 시간(전/후반 시작/종료) 등록 API 수정

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -14,6 +14,7 @@ import com.matchday.matchdayserver.match.service.MatchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -77,9 +78,9 @@ public class MatchController {
         return ApiResponse.ok(matchService.getMatchListByTeam(teamId));
     }
 
-    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> **halfTimeType**은 ``FIRST_HALF_TIME(전반) / SECOND_HALF_TIME(후반)`` 입니다. <br> **timeType**은 ``START_TIME(시작시간) / END_TIME(종료시간)``입니다. ")
+    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> **halfTimeType**은 ``FIRST_HALF_TIME(전반) / SECOND_HALF_TIME(후반)`` 입니다. <br> **timeType**은 ``START_TIME(시작시간) / END_TIME(종료시간)`` 입니다. ")
     @PatchMapping("/{matchId}/time")
-    public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @RequestBody MatchHalfTimeRequest matchHalfTimeRequest) {
+    public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @RequestBody @Valid MatchHalfTimeRequest matchHalfTimeRequest) {
         matchService.setHalfTime(matchId, matchHalfTimeRequest);
         return ApiResponse.ok("시간 등록 완료");
     }

--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -78,7 +78,7 @@ public class MatchController {
         return ApiResponse.ok(matchService.getMatchListByTeam(teamId));
     }
 
-    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> **halfTimeType**은 ``FIRST_HALF_TIME(전반) / SECOND_HALF_TIME(후반)`` 입니다. <br> **timeType**은 ``START_TIME(시작시간) / END_TIME(종료시간)`` 입니다. ")
+    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> **halfType**은 ``FIRST_HALF(전반) / SECOND_HALF(후반)`` 입니다. <br> **timeType**은 ``START_TIME(시작시간) / END_TIME(종료시간)`` 입니다. ")
     @PatchMapping("/{matchId}/time")
     public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @RequestBody @Valid MatchHalfTimeRequest matchHalfTimeRequest) {
         matchService.setHalfTime(matchId, matchHalfTimeRequest);

--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -77,10 +77,10 @@ public class MatchController {
         return ApiResponse.ok(matchService.getMatchListByTeam(teamId));
     }
 
-    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> halfType은 전반 `first`, 후반 `second` 입니다.<br>각 시간 단건 등록 가능합니다.<br> 전/후반 startTime, endTime 모두 `nullable` 입니다. ")
-    @PatchMapping("/{matchId}/{halfType}-time")
-    public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @PathVariable String halfType, @RequestBody MatchHalfTimeRequest matchHalfTimeRequest) {
-        matchService.setHalfTime(matchId, halfType, matchHalfTimeRequest);
+    @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> **halfTimeType**은 ``FIRST_HALF_TIME(전반) / SECOND_HALF_TIME(후반)`` 입니다. <br> **timeType**은 ``START_TIME(시작시간) / END_TIME(종료시간)``입니다. ")
+    @PatchMapping("/{matchId}/time")
+    public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @RequestBody MatchHalfTimeRequest matchHalfTimeRequest) {
+        matchService.setHalfTime(matchId, matchHalfTimeRequest);
         return ApiResponse.ok("시간 등록 완료");
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
@@ -1,6 +1,9 @@
 package com.matchday.matchdayserver.match.model.dto.request;
 
+import com.matchday.matchdayserver.match.model.enums.HalfTimeType;
+import com.matchday.matchdayserver.match.model.enums.TimeType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import java.time.LocalTime;
@@ -8,9 +11,16 @@ import java.time.LocalTime;
 @Getter
 @NoArgsConstructor
 public class MatchHalfTimeRequest {
-    @Schema(description = "시작 시간", nullable = true)
-    private LocalTime startTime;
 
-    @Schema(description = "종료 시간", nullable = true)
-    private LocalTime endTime;
+    @NotNull
+    @Schema(description = "전/후반 ")
+    private HalfTimeType halfTimeType;
+
+    @NotNull
+    @Schema(description = "시작/종료 시간")
+    private TimeType timeType;
+
+    @NotNull
+    @Schema(description = "기록할 시간")
+    private LocalTime time;
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchHalfTimeRequest.java
@@ -1,6 +1,6 @@
 package com.matchday.matchdayserver.match.model.dto.request;
 
-import com.matchday.matchdayserver.match.model.enums.HalfTimeType;
+import com.matchday.matchdayserver.match.model.enums.HalfType;
 import com.matchday.matchdayserver.match.model.enums.TimeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -14,7 +14,7 @@ public class MatchHalfTimeRequest {
 
     @NotNull
     @Schema(description = "전/후반 ")
-    private HalfTimeType halfTimeType;
+    private HalfType halfType;
 
     @NotNull
     @Schema(description = "시작/종료 시간")

--- a/src/main/java/com/matchday/matchdayserver/match/model/enums/HalfTimeType.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/enums/HalfTimeType.java
@@ -1,6 +1,0 @@
-package com.matchday.matchdayserver.match.model.enums;
-
-public enum HalfTimeType {
-    FIRST_HALF_TIME,
-    SECOND_HALF_TIME
-}

--- a/src/main/java/com/matchday/matchdayserver/match/model/enums/HalfTimeType.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/enums/HalfTimeType.java
@@ -1,0 +1,6 @@
+package com.matchday.matchdayserver.match.model.enums;
+
+public enum HalfTimeType {
+    FIRST_HALF_TIME,
+    SECOND_HALF_TIME
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/enums/HalfType.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/enums/HalfType.java
@@ -1,0 +1,6 @@
+package com.matchday.matchdayserver.match.model.enums;
+
+public enum HalfType {
+    FIRST_HALF,
+    SECOND_HALF
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/enums/TimeType.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/enums/TimeType.java
@@ -1,0 +1,6 @@
+package com.matchday.matchdayserver.match.model.enums;
+
+public enum TimeType {
+    START_TIME,  //시작 시간
+    END_TIME   //종료 시간
+}

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -8,7 +8,7 @@ import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.entity.Match;
-import com.matchday.matchdayserver.match.model.enums.HalfTimeType;
+import com.matchday.matchdayserver.match.model.enums.HalfType;
 import com.matchday.matchdayserver.match.model.enums.MatchState;
 import com.matchday.matchdayserver.match.model.enums.TimeType;
 import com.matchday.matchdayserver.match.model.mapper.MatchMapper;
@@ -85,7 +85,7 @@ public class MatchService {
       validateTime(match, halfTimeRequest);
 
         //전반 시작/종료 시간 등록
-        if (HalfTimeType.FIRST_HALF_TIME.equals(halfTimeRequest.getHalfTimeType())) {
+        if (HalfType.FIRST_HALF.equals(halfTimeRequest.getHalfType())) {
             //전반 시작 시간 등록
             if(TimeType.START_TIME.equals(halfTimeRequest.getTimeType())) {
                 match.setFirstHalfStartTime(halfTimeRequest.getTime());
@@ -99,7 +99,7 @@ public class MatchService {
         }
 
         //후반 시작/종료 시간 등록
-        if (HalfTimeType.SECOND_HALF_TIME.equals(halfTimeRequest.getHalfTimeType())) {
+        if (HalfType.SECOND_HALF.equals(halfTimeRequest.getHalfType())) {
             //후반 시작 시간 등록
             if(TimeType.START_TIME.equals(halfTimeRequest.getTimeType())) {
                 match.setSecondHalfStartTime(halfTimeRequest.getTime());
@@ -117,11 +117,11 @@ public class MatchService {
         LocalTime newTime = halfTimeRequest.getTime();
         if (newTime == null) return;
 
-        HalfTimeType halfType = halfTimeRequest.getHalfTimeType();
+        HalfType halfType = halfTimeRequest.getHalfType();
         TimeType timeType = halfTimeRequest.getTimeType();
 
         switch (halfType) {
-            case FIRST_HALF_TIME -> {
+            case FIRST_HALF -> {
                 LocalTime start = match.getFirstHalfStartTime();
                 LocalTime end = match.getFirstHalfEndTime();
 
@@ -133,7 +133,7 @@ public class MatchService {
                 }
             }
 
-            case SECOND_HALF_TIME -> {
+            case SECOND_HALF -> {
                 LocalTime start = match.getSecondHalfStartTime();
                 LocalTime end = match.getSecondHalfEndTime();
                 LocalTime firstHalfEnd = match.getFirstHalfEndTime();


### PR DESCRIPTION
## Related Issue

[MAT-174](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2/backlog?selectedIssue=MAT-174)

## Overview
- 매치 경기 시간 등록 API 수정 했습니다. 
- 주요 수정 사항은 MatchHalfTimeRequest DTO를 Enum 활용하여 변경한 것입니다.

## Screenshot
- 수정 전
<img width="607" alt="스크린샷 2025-05-13 오후 5 19 33" src="https://github.com/user-attachments/assets/7942d559-7999-44f2-8ac1-2754d32b9cf5" />

- 수정 후
<img width="645" alt="스크린샷 2025-05-13 오후 5 19 01" src="https://github.com/user-attachments/assets/41d1ca64-a333-4edb-a8e5-a56a0b0fd536" />





[MAT-174]: https://match-day.atlassian.net/browse/MAT-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 경기 시간 등록 시 전반/후반 및 시작/종료 시간을 명확하게 지정할 수 있도록 선택 항목이 추가되었습니다.
  - 전반과 후반, 시작 시간과 종료 시간을 나타내는 새로운 선택지가 도입되었습니다.

- **개선 사항**
  - 시간 등록 API가 단순화되어 요청 경로가 간편해졌으며, 요청 본문에서 전반/후반 및 시작/종료 시간을 직접 지정할 수 있습니다.
  - 시간 등록 시 유효성 검사가 강화되어 잘못된 시간 입력을 방지합니다.
  - 경기 상태가 전반 시작과 후반 종료 시점에 자동으로 업데이트됩니다.

- **응답 메시지**
  - 시간 등록 완료 시 명확한 성공 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->