### PR TITLE
[MAT-210] match player 조회시 matchUserId 조회 가능하도록 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -12,8 +12,12 @@ import lombok.Setter;
 public class MatchUserResponse {
 
     @NotNull
-    @Schema(description = "유저 ID", example = "12")
+    @Schema(description = "매치유저 ID", example = "5")
     private Long id;
+
+    @NotNull
+    @Schema(description = "유저 ID", example = "12")
+    private Long userId;
 
     @NotNull
     @Schema(description = "유저 이름", example = "홍길동")
@@ -62,10 +66,11 @@ public class MatchUserResponse {
     private boolean subOut;
 
     @Builder
-    public MatchUserResponse(Long id, String name, Integer number, String matchPosition, Integer matchGrid,
+    public MatchUserResponse(Long id, Long userId, String name, Integer number, String matchPosition, Integer matchGrid,
         Integer goals, Integer assists,
         Integer yellowCards, Integer redCards, Integer caution, boolean sentOff, String profileImg,boolean subIn, boolean subOut) {
         this.id = id;
+        this.userId = userId;
         this.name = name;
         this.number = number;
         this.matchPosition = matchPosition;

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -112,7 +112,8 @@ public class MatchUserService {
             boolean subOut = matchEventRepository.existsByMatchUserIdAndEventType(matchUser.getId(), MatchEventType.SUB_OUT);
 
             MatchUserResponse response = MatchUserResponse.builder()
-                .id(userId)
+                .id(matchUser.getId())
+                .userId(userId)
                 .name(userName)
                 .number(number)
                 .matchPosition(matchUser.getMatchPosition())


### PR DESCRIPTION
## Related Issue

[MAT-210](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-210)

## Overview
- 매치 플레이어 조회시 MatchUserId 조회 가능하도록 추가했습니다.
- 해당 응답 DTO의 **id -> matchUserId** 이고, **userId -> userId** 입니다.

## Screenshot
<img width="821" alt="스크린샷 2025-05-16 오후 3 28 03" src="https://github.com/user-attachments/assets/e3460ad9-54d3-483b-a1b7-90a403b70c81" />





[MAT-210]: https://match-day.atlassian.net/browse/MAT-210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 응답에 `userId`(유저 ID) 필드가 추가되었습니다.

- **버그 수정**
  - 기존 `id` 필드가 매치유저 ID로 명확하게 구분되어 반환됩니다.

- **문서화**
  - 응답 필드의 설명과 예시가 보다 명확하게 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->