### PR TITLE
[MAT-213] 그리드 위치 변경 시 중복 방지를 위한 검증 로직 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchUserStatus.java
@@ -3,7 +3,8 @@ package com.matchday.matchdayserver.common.response;
 public enum MatchUserStatus implements StatusInterface {
     NOTFOUND_MATCH(404, 7001, "존재하지 않는 매치입니다"),
     ALREADY_REGISTERED(400, 7002, "매치에 이미 등록된 유저입니다"),
-    NOTFOUND_MATCHUSER(404, 7003, "존재하지 않는 매치 유저입니다")
+    NOTFOUND_MATCHUSER(404, 7003, "존재하지 않는 매치 유저입니다"),
+    ALREADY_OCCUPYED(404,7004,"해당 좌표에 이미 누군가 배치되어있습니다")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -26,6 +26,9 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
 
   //특정 매치에 특정 유저가 존재하는지 여부
   boolean existsByMatchIdAndUserId(Long matchId, Long userId);
+
+  //특정 매치에 특정 번호의 그리드가 있는지 여부
+  boolean existsByMatchIdAndMatchGrid(Long matchId, Integer gridId);
   
   // 특정 유저가 참여한 매치 리스트 조회
   @Query("SELECT mu.match.id FROM MatchUser mu WHERE mu.user.id = :userId")

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -77,6 +77,11 @@ public class MatchUserService {
       MatchUser matchUser = matchUserRepository.findById(matchUserId)
           .orElseThrow(() -> new ApiException(MatchUserStatus.NOTFOUND_MATCHUSER));
 
+      //이미 해당 좌표가 점유되었는지 확인
+      if(matchUserRepository.existsByMatchIdAndMatchGrid(matchUser.getMatch().getId(),matchUserGridUpdateRequest.getMatchGrid())){
+          throw new ApiException(MatchUserStatus.ALREADY_OCCUPYED);
+      }
+
       matchUser.updateMatchGrid(matchUserGridUpdateRequest.getMatchGrid());
      matchUserRepository.save(matchUser);
   }


### PR DESCRIPTION
## Related Issue
https://match-day.atlassian.net/browse/MAT-213

## Overview

- updateMatchUserGrid 에 특정 Match에 특정 Grid가 점유되고 있는지 검증하는 로직을 추가하였습니다

## Screenshot

![image](https://github.com/user-attachments/assets/93f60dd6-576a-40f4-9484-a61316b470e7)







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 이미 다른 사용자가 해당 좌표에 배치된 경우, 좌표 선택 시 오류 메시지가 표시되어 중복 배치를 방지합니다.

- **버그 수정**
  - 매치 내 동일 좌표에 여러 사용자가 배치되는 문제를 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->