### PR TITLE
[MAT-288] 선수 교체시 교체 선수의 grid만 복사되게 수정

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -62,18 +62,14 @@ public class MatchUser {
         this.matchGrid = matchGrid;
     }
 
-    public void exchange(MatchUser toMatchUser) {
-        if (!toMatchUser.getTeam().getId().equals(this.team.getId())) {
+    public void substituteTo(MatchUser subInPlayer) {
+        if (!subInPlayer.getTeam().getId().equals(this.team.getId())) {
             throw new ApiException(MatchStatus.DIFFERENT_TEAM_EXCHANGE);
         }
-        String originalPosition = toMatchUser.getMatchPosition();
-        int originalGrid = toMatchUser.getMatchGrid();
-        toMatchUser.updateMatchPosition(this.matchPosition);
-        toMatchUser.updateMatchGrid(this.matchGrid);
 
-        this.matchPosition = originalPosition;
-        this.matchGrid = originalGrid;
+        subInPlayer.updateMatchGrid(this.matchGrid);
     }
+
 
     // 퇴장시키는 메서드
     public void sendOff() {

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/entity/MatchUser.java
@@ -54,10 +54,6 @@ public class MatchUser {
     @OneToMany(mappedBy = "matchUser", cascade = CascadeType.REMOVE)
     private List<MatchEvent> matchEvents;
 
-    public void updateMatchPosition(String matchPosition) {
-        this.matchPosition = matchPosition;
-    }
-
     public void updateMatchGrid(int matchGrid) {
         this.matchGrid = matchGrid;
     }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
@@ -43,7 +43,7 @@ public class MatchUserExchangeService {
             .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
 
         // Dirty Checking으로 자동 저장
-        fromMatchUser.exchange(toMatchUser);
+        fromMatchUser.substituteTo(toMatchUser);
 
         List<MatchEvent> matchEvents = List.of(
             MatchEvent.builder()


### PR DESCRIPTION
## Related Issue
[MAT-288](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-228)

## Overview
- 선수 교체시 교체 Out 되는 선수의 grid를 교체 In 되는 선수에게 복사하도록 수정 했습니다.
- 포지션은 수정 되지 않게 변경 했습니다.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 교체 기능에서 교체되는 선수의 위치 정보가 올바르게 업데이트되도록 개선되었습니다.
  - 선수 교체 시 위치 정보 교환 방식이 단순화되어 안정성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->