### PR TITLE
[MAT-231] 통합 테스트 세팅 및 임시 유저 생성 테스트 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/ApiResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/ApiResponse.java
@@ -24,6 +24,11 @@ public class ApiResponse<T> {
         return new ApiResponse<>(HttpStatus.OK.value(), data, DefaultStatus.OK.getDescription());
     }
 
+    public static <T> ApiResponse<T> created(T data) {
+        return new ApiResponse<>(HttpStatus.CREATED.value(), data, DefaultStatus.OK.getDescription());
+    }
+
+
     public static <T> ApiResponse<T> error(StatusInterface status) {
         return new ApiResponse<>(status.getCustomStatusCode(), null, status.getDescription());
     }

--- a/src/main/java/com/matchday/matchdayserver/user/controller/UserController.java
+++ b/src/main/java/com/matchday/matchdayserver/user/controller/UserController.java
@@ -9,7 +9,9 @@ import com.matchday.matchdayserver.user.model.dto.response.UserInfoResponse;
 import com.matchday.matchdayserver.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "users", description = "유저 관련 API")
@@ -22,11 +24,12 @@ public class UserController {
     private final S3PresignedService s3PresignedManager;
     private static final String FOLDER_NAME = "users";
 
+    @ResponseStatus(HttpStatus.CREATED)
     @Operation(summary = "임시 유저 생성" , description = "생성된 user의 Id 값 반환 <br> profileImg는 선택 사항입니다.")
     @PostMapping
-    public ApiResponse<Long> createUser(@RequestBody UserCreateRequest request) {
+    public ApiResponse<Long> createUser(@Valid @RequestBody UserCreateRequest request) {
         Long userId=userService.createUser(request);
-        return ApiResponse.ok(userId);
+        return ApiResponse.created(userId);
     }
 
     @Operation(summary = "팀 입단", description = "{userId}가 teamId에 소속됩니다 ")

--- a/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/dto/request/UserCreateRequest.java
@@ -1,15 +1,18 @@
 package com.matchday.matchdayserver.user.model.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class UserCreateRequest {
 
-    @NotNull
+    @NotBlank
     @Schema(description = "유저 이름", example = "홍길동")
     private String name;
 

--- a/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
+++ b/src/main/java/com/matchday/matchdayserver/user/service/UserService.java
@@ -35,7 +35,6 @@ public class UserService {
     private final MatchUserRepository matchUserRepository;
 
     public Long createUser(UserCreateRequest request){
-        validateDuplicateUser(request.getName());
         User user = new User(request.getName(), request.getProfileImg());
         userRepository.save(user);
         return user.getId();
@@ -63,13 +62,6 @@ public class UserService {
         //객체 저장
         userTeamRepository.save(userTeam);
         return UserTeamMapper.toJoinUserTeamResponse(userTeam);
-    }
-
-    //유저 이름 중복 체크
-    private void validateDuplicateUser(String name) {
-        if (userRepository.existsByName(name)) {
-            throw new ApiException(UserStatus.DUPLICATE_USERNAME);
-        }
     }
 
     public boolean existsById(Long userId) {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,39 @@
+spring:
+    config:
+        import: optional:file:.env[.properties]
+    application:
+        name: matchday-server
+    datasource:
+        url: ${SPRING_TEST_DATASOURCE_URL}
+        username: ${SPRING_DATASOURCE_USERNAME}
+        password: ${SPRING_DATASOURCE_PASSWORD}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+
+    jpa:
+        hibernate:
+            ddl-auto: create
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.MySQLDialect
+
+    cloud:
+        aws:
+            s3:
+                bucket: ${BUCKET_NAME}
+            stack:
+                auto: false
+            region:
+                static: ${AWS_REGION}
+            credentials:
+                access-key: ${AWS_ACCESS_KEY}
+                secret-key: ${AWS_SECRET_KEY}
+
+springdoc:
+    api-docs:
+        version: "openapi_3_0"
+        url: "https://dev-api.matchday-planner.com"
+
+decorator:
+    datasource:
+        p6spy:
+            enable-logging: false

--- a/src/test/java/com/matchday/matchdayserver/user/controller/UserControllerCreateTest.java
+++ b/src/test/java/com/matchday/matchdayserver/user/controller/UserControllerCreateTest.java
@@ -71,7 +71,7 @@ public class UserControllerCreateTest {
 
     @Test
     @DisplayName("임시 유저 생성 - 중복된 이름인 경우도 생성됨")
-    void createUser_Fail_DuplicateName() throws Exception {
+    void createUser_Success_DuplicateName() throws Exception {
         // given
         String duplicateName = "중복이름";
 
@@ -89,7 +89,8 @@ public class UserControllerCreateTest {
         // then
         actions
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.status").value(201)); // 사용자 중복 에러 코드 가정
+                .andExpect(jsonPath("$.status").value(201)); // 중복 이름도 허용되어 성공적으로 생성됨
+
     }
 
     @Test

--- a/src/test/java/com/matchday/matchdayserver/user/controller/UserControllerCreateTest.java
+++ b/src/test/java/com/matchday/matchdayserver/user/controller/UserControllerCreateTest.java
@@ -1,0 +1,136 @@
+package com.matchday.matchdayserver.user.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matchday.matchdayserver.user.model.dto.request.UserCreateRequest;
+import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.user.repository.UserRepository;
+
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:application-test.yml")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class UserControllerCreateTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("임시 유저 생성 - 정상 케이스")
+    void createUser_Success() throws Exception {
+        // given
+        UserCreateRequest request = new UserCreateRequest("테스트유저", null);
+
+        // when
+        ResultActions actions = mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        actions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.data").isNumber())
+                .andExpect(jsonPath("$.message").value("OK"));
+    }
+
+    @Test
+    @DisplayName("임시 유저 생성 - 이름이 null인 경우")
+    void createUser_Fail_NameIsNull() throws Exception {
+        // given
+        UserCreateRequest request = new UserCreateRequest();
+        // name을 설정하지 않음 (null)
+
+        // when
+        ResultActions actions = mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        actions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("임시 유저 생성 - 중복된 이름인 경우도 생성됨")
+    void createUser_Fail_DuplicateName() throws Exception {
+        // given
+        String duplicateName = "중복이름";
+
+        // 먼저 동일한 이름으로 유저 생성
+        User existingUser = new User(duplicateName, null);
+        userRepository.save(existingUser);
+
+        UserCreateRequest request = new UserCreateRequest(duplicateName, null);
+
+        // when
+        ResultActions actions = mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        actions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201)); // 사용자 중복 에러 코드 가정
+    }
+
+    @Test
+    @DisplayName("임시 유저 생성 - 프로필 이미지 포함")
+    void createUser_WithProfileImg() throws Exception {
+        // given
+        UserCreateRequest request = new UserCreateRequest("프로필이미지유저", "users/1/test-image.png");
+
+        // when
+        ResultActions actions = mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        actions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.data").isNumber());
+        
+        // 생성된 사용자의 프로필 이미지 확인
+        Long userId = objectMapper.readTree(
+                actions.andReturn().getResponse().getContentAsString())
+                .get("data").asLong();
+        
+        User createdUser = userRepository.findById(userId).orElseThrow();
+        assert createdUser.getProfileImg().equals("users/1/test-image.png");
+    }
+    
+    @Test
+    @DisplayName("임시 유저 생성 - 이름이 공백인 경우")
+    void createUser_Fail_EmptyName() throws Exception {
+        // given
+        UserCreateRequest request = new UserCreateRequest("", null);
+
+        // when
+        ResultActions actions = mockMvc.perform(post("/api/v1/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        actions
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-231

## Overview

- 통합 테스트 세팅 및 임시 유저 생성 테스트 구현 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 사용자 생성 API에서 성공적으로 사용자를 생성하면 201(Created) 상태 코드와 함께 응답하도록 개선되었습니다.
	- 사용자 생성 시 프로필 이미지 경로를 포함할 수 있습니다.
- **버그 수정**
	- 사용자 생성 시 이름 필드에 공백만 입력되는 경우를 방지하도록 검증이 강화되었습니다.
	- 사용자 생성 시 중복 이름에 대한 검증이 제거되었습니다.
- **테스트**
	- 사용자 생성 API에 대한 다양한 시나리오(성공, 이름 누락, 중복 이름, 프로필 이미지 포함, 빈 이름)에 대한 테스트가 추가되었습니다.
- **문서화**
	- 테스트 환경을 위한 별도의 설정 파일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->