### PR TITLE
[MAT-232] 파생되는 이벤트말고 메인 이벤트만 ws로 전송하도록 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -42,11 +42,8 @@ public class MatchEventSaveService {
 
         List<MatchEventResponse> matchEventResponse = matchEventStrategy
             .generateMatchEventLog(request, match, matchUser);
-        for (MatchEventResponse response : matchEventResponse) {
-            if (!neededToSendEvent(response.getEventLog())) {
-                continue;
-            }
-            messagingTemplate.convertAndSend("/topic/match/" + matchId, response);
+        if(!matchEventResponse.isEmpty()) {
+            messagingTemplate.convertAndSend("/topic/match" + matchId, matchEventResponse.get(0));
         }
     }
 
@@ -61,23 +58,9 @@ public class MatchEventSaveService {
 
         List<MatchEventResponse> matchEventResponse = matchEventStrategy
             .generateMatchEventLog(request, match, matchUser);
-        for (MatchEventResponse response : matchEventResponse) {
-            if (!neededToSendEvent(response.getEventLog())) {
-                continue;
-            }
-            messagingTemplate.convertAndSend("/topic/match/" + matchId, response);
+        if (!matchEventResponse.isEmpty()) {
+            messagingTemplate.convertAndSend("/topic/match/" + matchId, matchEventResponse.get(0));
         }
-    }
-
-    private boolean neededToSendEvent(MatchEventType matchEventType) {
-        return MatchEventType.GOAL.equals(matchEventType)
-            || MatchEventType.ASSIST.equals(matchEventType)
-            || MatchEventType.OFFSIDE.equals(matchEventType)
-            || MatchEventType.YELLOW_CARD.equals(matchEventType)
-            || MatchEventType.RED_CARD.equals(matchEventType)
-            || MatchEventType.SUB_IN.equals(matchEventType)
-            || MatchEventType.SUB_OUT.equals(matchEventType)
-            ;
     }
 
     private void validateRequest(Long matchId, MatchEventUserRequest request) {


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 경기 이벤트 메시지 전송 방식이 개선되어, 이벤트 목록 중 첫 번째 이벤트만 전송하도록 변경되었습니다.
  - 일부 메시지 전송 경로가 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->