### PR TITLE
[MAT-234] 전체 매치 리스트 조회 API

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
@@ -18,7 +18,9 @@ public enum MatchStatus implements StatusInterface {
     INVALID_TIME_RANGE(400, 6015,"종료 시간은 시작 시간보다 늦어야합니다"),
     SECOND_HALF_TIME_ERROR(400, 6016,"후반 시작 시간은 전반 종료 시간 보다 늦어야합니다"),
     NOTFOUND_MATCH_EVENT(404, 6017, "존재하지 않는 경기 이벤트입니다"),
-    INVALID_HALF_PERIOD(404,6018,"유효한 경기 기간은 1분~45분입니다")
+    INVALID_HALF_PERIOD(404,6018,"유효한 경기 기간은 1분~45분입니다"),
+    INVALID_PAGE_NUMBER(400, 6019, "page는 음수 값이 될 수 없습니다."),
+    INVALID_PAGE_SIZE(400, 6020, "size는 1이상의 값이어야 합니다.")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -5,6 +5,7 @@ import com.matchday.matchdayserver.match.model.dto.request.MatchCreateRequest;
 import com.matchday.matchdayserver.match.model.dto.request.MatchMemoRequest;
 import com.matchday.matchdayserver.match.model.dto.request.MatchHalfTimeRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchListPageResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchMemoResponse;
@@ -22,8 +23,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import java.time.LocalTime;
 import java.util.List;
 
 @Tag(name = "matches", description = "매치 관련 API")
@@ -72,10 +73,19 @@ public class MatchController {
       return ApiResponse.ok(matchService.get(matchId));
     }
 
-    @Operation(summary = "매치 리스트 조회", description = "특정 팀이 속한 매치 리스트를 조회합니다. <br> 경기 상태(matchStatus) 값은 SCHEDULED(경기 전), IN_PLAY(경기중), FINISHED(경기 종료) 입니다.")
+    @Operation(summary = "특정 팀 매치 리스트 조회", description = "특정 팀이 속한 매치 리스트를 조회합니다. <br> 경기 상태(matchStatus) 값은 SCHEDULED(경기 전), IN_PLAY(경기중), FINISHED(경기 종료) 입니다.")
     @GetMapping("/teams/{teamId}")
     public ApiResponse<List<MatchListResponse>> getMatchList(@PathVariable Long teamId) {
         return ApiResponse.ok(matchService.getMatchListByTeam(teamId));
+    }
+
+    @Operation(summary = "전체 매치 리스트 조회", description = " 전체 매치 리스트를 페이징하여 조회합니다.<br> `page: 0부터 시작하는 페이지 번호 (기본값 0)` <br> `size: 한 페이지에 포함할 데이터 개수 (기본값 10)`<br>")
+    @GetMapping()
+    public ApiResponse<MatchListPageResponse> getPagedMatchList(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.ok(matchService.getMatchList(page, size));
     }
 
     @Operation(summary = "전/후반 시간 등록", description = "특정 매치의 전/후반 시작/종료 시간을 등록합니다. <br> **halfType**은 ``FIRST_HALF(전반) / SECOND_HALF(후반)`` 입니다. <br> **timeType**은 ``START_TIME(시작시간) / END_TIME(종료시간)`` 입니다. ")

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchListPageResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchListPageResponse.java
@@ -1,0 +1,23 @@
+package com.matchday.matchdayserver.match.model.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Schema(description = "페이징용 매치 리스트 응답 객체")
+public class MatchListPageResponse {
+
+    @Schema(description = "전체 매치 개수", example = "5")
+    private final long totalCount;
+
+    @Schema(description = "현재 페이지 매치 리스트")
+    private final List<MatchListResponse> matches;
+
+    @Builder
+    public MatchListPageResponse(long totalCount, List<MatchListResponse> matches) {
+        this.totalCount = totalCount;
+        this.matches = matches;
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/repository/MatchRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/match/repository/MatchRepository.java
@@ -2,8 +2,14 @@ package com.matchday.matchdayserver.match.repository;
 
 import com.matchday.matchdayserver.match.model.entity.Match;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface MatchRepository extends JpaRepository<Match, Long> {
     List<Match> findByHomeTeamIdOrAwayTeamId(Long homeTeamId, Long awayTeamId);
+
+    @Query(value = "SELECT * FROM `match` ORDER BY id LIMIT :limit OFFSET :offset", nativeQuery = true)
+    List<Match> findMatchesByOffsetAndLimit(@Param("offset") int offset, @Param("limit") int limit);
+
 }

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -79,7 +79,23 @@ public class MatchService {
   }
 
   public MatchListPageResponse getMatchList(int page, int size) {
-        long totalCount = matchRepository.count();
+      // 유효성 검사
+      if (page < 0) {
+          throw new ApiException(MatchStatus.INVALID_PAGE_NUMBER);
+      }
+      if (size <= 0) {
+          throw new ApiException(MatchStatus.INVALID_PAGE_SIZE);
+      }
+
+      long totalCount = matchRepository.count();
+
+      // 데이터가 없는 경우 빈 응답 반환
+      if (totalCount == 0) {
+          return MatchListPageResponse.builder()
+              .totalCount(0)
+              .matches(List.of())
+              .build();
+      }
 
         int offset = page * size;
 

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -5,6 +5,7 @@ import com.matchday.matchdayserver.common.response.MatchStatus;
 import com.matchday.matchdayserver.common.response.TeamStatus;
 import com.matchday.matchdayserver.match.model.dto.request.MatchHalfTimeRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchListPageResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.entity.Match;
@@ -76,6 +77,26 @@ public class MatchService {
           })
           .collect(Collectors.toList());
   }
+
+  public MatchListPageResponse getMatchList(int page, int size) {
+        long totalCount = matchRepository.count();
+
+        int offset = page * size;
+
+        List<Match> matches = matchRepository.findMatchesByOffsetAndLimit(offset, size);
+
+        List<MatchListResponse> responseList = matches.stream()
+            .map(match -> {
+                MatchScoreResponse scoreRes = matchScoreService.getMatchScore(match.getId());
+                return MatchMapper.toMatchListResponse(match, scoreRes);
+            })
+            .collect(Collectors.toList());
+
+        return MatchListPageResponse.builder()
+            .totalCount(totalCount)
+            .matches(responseList)
+            .build();
+    }
 
     @Transactional
     public void setHalfTime(Long id, MatchHalfTimeRequest halfTimeRequest) {


### PR DESCRIPTION
## Related Issue

[MAT-234](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-234)

## Overview
- 전체 매치 리스트 조회 API 구현
- page와 size를 param 값으로 받아 페이징 하도록 구현 했습니다.

## Screenshot
<img width="726" alt="스크린샷 2025-05-18 오후 4 07 06" src="https://github.com/user-attachments/assets/7ee94ba7-511e-4ec5-b64f-3f643c4efa74" />







[MAT-234]: https://match-day.atlassian.net/browse/MAT-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 모든 매치 목록을 페이지네이션 방식으로 조회할 수 있는 엔드포인트가 추가되었습니다. 이제 페이지와 사이즈 파라미터를 통해 매치 목록을 나누어 확인할 수 있습니다.  
- **문서화**
    - 특정 팀 매치 리스트 조회 엔드포인트의 설명이 더 명확하게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->