### PR TITLE
[MAT-198] matchEventQuery 하드코딩된 String 값 Enum으로 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/EventTypeCount.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/model/dto/EventTypeCount.java
@@ -1,6 +1,7 @@
 package com.matchday.matchdayserver.matchevent.model.dto;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
 
-public interface EventTypeCount {//쿼리 결과를 맵핑시키기 위해 사용 (인터페이스 DTO)
-    String getEventType();
+public interface EventTypeCount {
+    MatchEventType getEventType();  // enum으로 변경
     Long getCount();
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -24,19 +24,19 @@ public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
 
     void deleteByMatchId(Long matchId);
 
-    @Query(value = """
-        SELECT 
-          event_type AS eventType,
-          COUNT(*) AS count
-        FROM match_event
-        WHERE match_user_id = :matchUserId
-          AND match_id = :matchId
-        GROUP BY event_type
-        """, nativeQuery = true)
+    @Query("""
+    SELECT e.eventType AS eventType,
+           COUNT(e) AS count
+    FROM MatchEvent e
+    WHERE e.matchUser.id = :matchUserId
+      AND e.match.id = :matchId
+    GROUP BY e.eventType
+    """)
     List<EventTypeCount> countEventTypesByMatchUserAndMatch(
         @Param("matchUserId") Long matchUserId,
         @Param("matchId") Long matchId
     );
+
 
     boolean existsByMatchUserIdAndEventType(Long matchUserId, MatchEventType eventType);
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -24,11 +24,11 @@ public class MatchEventQueryService {
         List<EventTypeCount> counts = matchEventRepository.countEventTypesByMatchUserAndMatch(matchUserId, matchId);
         for (EventTypeCount c : counts) {
             switch (c.getEventType()) {
-                case "GOAL" -> goals = c.getCount().intValue();
-                case "ASSIST" -> assists = c.getCount().intValue();
-                case "YELLOW_CARD" -> yellowCards = c.getCount().intValue();
-                case "RED_CARD" -> redCards = c.getCount().intValue();
-                case "WARNING" -> cautions = c.getCount().intValue();
+                case GOAL -> goals = c.getCount().intValue();
+                case ASSIST -> assists = c.getCount().intValue();
+                case YELLOW_CARD -> yellowCards = c.getCount().intValue();
+                case RED_CARD -> redCards = c.getCount().intValue();
+                case WARNING -> cautions = c.getCount().intValue();
             }
         }
 


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-198

## Overview

- getMatchUserEventStat 메소드 내부 switch문에서 case 분기로 String이 아닌 MatchEventType인 ENUMS 값을 사용합니다

![image](https://github.com/user-attachments/assets/4b7876dd-3e1b-4db2-9fe4-44a7b2881ec0)




