### PR TITLE
[MAT-235] 매치 정보 응답 DTO에 경기명 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchInfoResponse.java
@@ -25,6 +25,10 @@ public class MatchInfoResponse {
     private Long awayTeamId;
 
     @NotNull
+    @Schema(description = "경기명", example = "K리그 결승")
+    private String title;
+
+    @NotNull
     @Schema(description = "장소", example = "경기 장소")
     private String stadium;
 
@@ -73,13 +77,14 @@ public class MatchInfoResponse {
     private LocalTime secondHalfEndTime;
 
     @Builder
-    public MatchInfoResponse(Long id, String stadium, LocalDate matchDate, LocalTime plannedStartTime,
+    public MatchInfoResponse(Long id, String title, String stadium, LocalDate matchDate, LocalTime plannedStartTime,
         LocalTime plannedEndTime, Integer firstHalfPeriod, Integer secondHalfPeriod,
         String mainRefereeName, String assistantReferee1, String assistantReferee2, String fourthReferee,
         LocalTime firstHalfStartTime, LocalTime firstHalfEndTime,
         LocalTime secondHalfStartTime, LocalTime secondHalfEndTime,
         Long homeTeamId, Long awayTeamId) {
         this.id = id;
+        this.title = title;
         this.stadium = stadium;
         this.matchDate = matchDate;
         this.plannedStartTime = plannedStartTime;

--- a/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
@@ -10,6 +10,7 @@ public class MatchMapper {
     public static MatchInfoResponse toResponse(Match match) {
         return MatchInfoResponse.builder()
             .id(match.getId())
+            .title(match.getTitle())
             .stadium(match.getStadium())
             .matchDate(match.getMatchDate())
             .plannedStartTime(match.getPlannedStartTime())


### PR DESCRIPTION
## Related Issue

[MAT-235](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-235)

## Overview
- 매치 정보(matchInfo) 응답 DTO에 경기명 추가 했습니다.

## Screenshot
<img width="424" alt="스크린샷 2025-05-18 오후 4 38 40" src="https://github.com/user-attachments/assets/8451112d-386d-40c6-afd2-ec0df1dbd328" />







[MAT-235]: https://match-day.atlassian.net/browse/MAT-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 경기 정보 응답에 '경기명' 필드가 추가되어, 경기의 제목이 함께 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->