### PR TITLE
feat(match): 특정 팀의 매치 결과 리스트 조회 구현

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
+++ b/src/main/java/com/matchday/matchdayserver/match/controller/MatchController.java
@@ -7,9 +7,11 @@ import com.matchday.matchdayserver.match.model.dto.request.MatchHalfTimeRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListPageResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchResultInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchMemoResponse;
 import com.matchday.matchdayserver.match.service.MatchCreateService;
+import com.matchday.matchdayserver.match.service.MatchResultService;
 import com.matchday.matchdayserver.match.service.MatchScoreService;
 import com.matchday.matchdayserver.match.service.MatchService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,6 +37,7 @@ public class MatchController {
     private final MatchCreateService matchCreateService;
     private final MatchService matchService;
     private final MatchScoreService matchScoreService;
+    private final MatchResultService matchResultService;
 
     @Operation(summary = "매치 생성")
     @PostMapping
@@ -93,5 +96,13 @@ public class MatchController {
     public ApiResponse<String> updateHalfTime(@PathVariable Long matchId, @RequestBody @Valid MatchHalfTimeRequest matchHalfTimeRequest) {
         matchService.setHalfTime(matchId, matchHalfTimeRequest);
         return ApiResponse.ok("시간 등록 완료");
+    }
+
+    @GetMapping("/teams/{teamId}/result")
+    public ApiResponse<List<MatchResultInfoResponse>> getMatchResultByTeam(
+        @PathVariable Long teamId) {
+
+        List<MatchResultInfoResponse> response = matchResultService.getMatchResultsByTeam(teamId);
+        return ApiResponse.ok(response);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchResultInfoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchResultInfoResponse.java
@@ -1,0 +1,93 @@
+package com.matchday.matchdayserver.match.model.dto.response;
+
+import com.matchday.matchdayserver.match.model.enums.MatchResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "매치 결과 정보 응답 객체")
+public class MatchResultInfoResponse {
+
+    @NotNull
+    @Schema(description = "매치 ID", example = "1")
+    private Long matchId;
+
+    @NotNull
+    @Schema(description = "홈팀 ID", example = "1")
+    private Long homeTeamId;
+
+    @NotNull
+    @Schema(description = "홈팀명", example = "토트넘")
+    private String homeTeamName;
+
+    @NotNull
+    @Schema(description = "상대팀 ID", example = "2")
+    private Long awayTeamId;
+
+    @NotNull
+    @Schema(description = "상대팀명", example = "레알 마드리드")
+    private String awayTeamName;
+
+    @NotNull
+    @Schema(description = "매치명", example = "프리미어리그 결승")
+    private String matchTitle;
+
+    @NotNull
+    @Schema(description = "매치 결과", example = "WIN")
+    private MatchResult matchResult;
+
+    @Schema(description = "홈팀 스코어", example = "3")
+    private int homeScore;
+
+    @Schema(description = "상대팀 스코어", example = "1")
+    private int awayScore;
+
+    @NotNull
+    @Schema(description = "경기 시간")
+    private int matchTime;
+
+    @NotNull
+    @Schema(description = "출전 선수")
+    private int playerCount;
+
+    @NotNull
+    @Schema(description = "매치 장소", example = "토트넘 스타디움")
+    private String stadium;
+
+    @Schema(description = "경기 일시")
+    private LocalDate matchDate;
+
+    @Builder
+    public MatchResultInfoResponse(Long matchId,
+        Long homeTeamId,
+        String homeTeamName,
+        Long awayTeamId,
+        String awayTeamName,
+        String matchTitle,
+        MatchResult matchResult,
+        int homeScore, int awayScore,
+        int matchTime,
+        int playerCount,
+        String stadium,
+        LocalDate matchDate) {
+        this.matchId = matchId;
+        this.homeTeamId = homeTeamId;
+        this.homeTeamName = homeTeamName;
+        this.awayTeamId = awayTeamId;
+        this.awayTeamName = awayTeamName;
+        this.matchTitle = matchTitle;
+        this.matchResult = matchResult;
+        this.homeScore = homeScore;
+        this.awayScore = awayScore;
+        this.matchTime = matchTime;
+        this.playerCount = playerCount;
+        this.stadium = stadium;
+        this.matchDate = matchDate;
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/enums/MatchResult.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/enums/MatchResult.java
@@ -1,0 +1,7 @@
+package com.matchday.matchdayserver.match.model.enums;
+
+public enum MatchResult {
+    WIN,    // 승
+    LOSE,   // 패
+    DRAW    //무승부
+}

--- a/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/mapper/MatchMapper.java
@@ -2,8 +2,10 @@ package com.matchday.matchdayserver.match.model.mapper;
 
 import com.matchday.matchdayserver.match.model.dto.response.MatchInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchListResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchResultInfoResponse;
 import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
 import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.model.enums.MatchResult;
 
 public class MatchMapper {
     // Match → MatchInfoResponse 변환
@@ -44,6 +46,29 @@ public class MatchMapper {
             .homeScore(scoreResponse.getHomeScore().getGoalCount())
             .awayScore(scoreResponse.getAwayScore().getGoalCount())
             .matchState(match.getMatchState())
+            .build();
+    }
+
+    public static MatchResultInfoResponse toMatchResultInfoResponse(
+        Match match,
+        MatchResult matchResult,
+        int matchTime,
+        int playerCount, MatchScoreResponse scoreResponse
+    ) {
+        return MatchResultInfoResponse.builder()
+            .matchId(match.getId())
+            .homeTeamId(match.getHomeTeam().getId())
+            .homeTeamName(match.getHomeTeam().getName())
+            .awayTeamId(match.getAwayTeam().getId())
+            .awayTeamName(match.getAwayTeam().getName())
+            .matchTitle(match.getTitle())
+            .matchResult(matchResult)
+            .homeScore(scoreResponse.getHomeScore().getGoalCount())
+            .awayScore(scoreResponse.getAwayScore().getGoalCount())
+            .matchTime(matchTime)
+            .playerCount(playerCount)
+            .stadium(match.getStadium())
+            .matchDate(match.getMatchDate())
             .build();
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/match/repository/MatchRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/match/repository/MatchRepository.java
@@ -12,4 +12,6 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
     @Query(value = "SELECT * FROM `match` ORDER BY id LIMIT :limit OFFSET :offset", nativeQuery = true)
     List<Match> findMatchesByOffsetAndLimit(@Param("offset") int offset, @Param("limit") int limit);
 
+    List<Match> findAllByHomeTeamIdOrAwayTeamId(Long homeTeamId, Long awayTeamId);
+
 }

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchResultService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchResultService.java
@@ -1,0 +1,116 @@
+package com.matchday.matchdayserver.match.service;
+
+import com.matchday.matchdayserver.match.model.dto.response.MatchResultInfoResponse;
+import com.matchday.matchdayserver.match.model.dto.response.MatchScoreResponse;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.model.enums.MatchResult;
+import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.matchuser.model.entity.MatchUser;
+import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MatchResultService {
+
+    private final MatchRepository matchRepository;
+    private final MatchScoreService matchScoreService;
+    private final MatchUserRepository matchUserRepository;
+
+    public List<MatchResultInfoResponse> getMatchResultsByTeam(Long teamId) {
+        List<Match> matches = matchRepository.findAllByHomeTeamIdOrAwayTeamId(teamId, teamId);
+
+        // 2. 각 경기마다 팀 기준으로 결과 계산 후 DTO 리스트 생성
+        return matches.stream()
+            .map(match -> {
+                Long matchId = match.getId();
+
+                MatchScoreResponse scoreResponse = matchScoreService.getMatchScore(matchId);
+                MatchResult matchResult = calculateMatchResult(scoreResponse, teamId, match);
+                int matchTime = calculateActualMatchTime(match);
+                int playerCount = countPlayersOnField(matchId);
+
+                return MatchResultInfoResponse.builder()
+                    .matchId(matchId)
+                    .homeTeamId(match.getHomeTeam().getId())
+                    .homeTeamName(match.getHomeTeam().getName())
+                    .awayTeamId(match.getAwayTeam().getId())
+                    .awayTeamName(match.getAwayTeam().getName())
+                    .matchTitle(match.getTitle())
+                    .matchResult(matchResult)
+                    .homeScore(scoreResponse.getHomeScore().getGoalCount())
+                    .awayScore(scoreResponse.getAwayScore().getGoalCount())
+                    .matchTime(matchTime)
+                    .playerCount(playerCount)
+                    .stadium(match.getStadium())
+                    .matchDate(match.getMatchDate())
+                    .build();
+            })
+            .collect(Collectors.toList());
+    }
+
+    // 경기 결과 계산 (팀 입장 기준)
+    private MatchResult calculateMatchResult(MatchScoreResponse score, Long teamId, Match match) {
+        int homeGoals = score.getHomeScore().getGoalCount();
+        int awayGoals = score.getAwayScore().getGoalCount();
+
+        MatchResult overallResult;
+        if (homeGoals > awayGoals) {
+            overallResult = MatchResult.WIN;
+        } else if (homeGoals < awayGoals) {
+            overallResult = MatchResult.LOSE;
+        } else {
+            overallResult = MatchResult.DRAW;
+        }
+
+        boolean isHomeTeam = match.getHomeTeam().getId().equals(teamId);
+
+        if (overallResult == MatchResult.DRAW) {
+            return MatchResult.DRAW;
+        }
+
+        if (overallResult == MatchResult.WIN) {
+            return isHomeTeam ? MatchResult.WIN : MatchResult.LOSE;
+        } else {
+            return isHomeTeam ? MatchResult.LOSE : MatchResult.WIN;
+        }
+    }
+
+    // 경기 실제 시간 계산
+    public int calculateActualMatchTime(Match match) {
+        int firstHalfMinutes = 0;
+        int secondHalfMinutes = 0;
+
+        LocalTime firstStart = match.getFirstHalfStartTime();
+        LocalTime firstEnd = match.getFirstHalfEndTime();
+        LocalTime secondStart = match.getSecondHalfStartTime();
+        LocalTime secondEnd = match.getSecondHalfEndTime();
+
+        if (firstStart != null && firstEnd != null) {
+            firstHalfMinutes = (int) Duration.between(firstStart, firstEnd).toMinutes();
+        }
+
+        if (secondStart != null && secondEnd != null) {
+            secondHalfMinutes = (int) Duration.between(secondStart, secondEnd).toMinutes();
+        }
+
+        return firstHalfMinutes + secondHalfMinutes;
+    }
+
+    // 출전 선수 수 조회
+    public int countPlayersOnField(Long matchId) {
+        List<MatchUser> matchUsers = matchUserRepository.findByMatchId(matchId);
+
+        return (int) matchUsers.stream()
+            .filter(mu -> mu.getMatchPosition() != null && mu.getMatchGrid() != null)
+            .count();
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -40,4 +40,8 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
    * @return
   */
   List<MatchUser> findByMatchIdAndTeamIdIsNotNullAndUserIdIsNotNull(Long matchId);
+
+    // 특정 경기의 모든 MatchUser 조회
+    List<MatchUser> findByMatchId(Long matchId);
+
 }


### PR DESCRIPTION
## Related Issue


## Overview
- 특정 팀의 경기 결과 리스트 조회 API 입니다

## Screenshot
<img width="820" alt="스크린샷 2025-05-18 오후 11 47 47" src="https://github.com/user-attachments/assets/451915e4-ce16-4ffd-a30a-103efa956b42" />








<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 특정 팀의 모든 경기 결과를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
    - 경기 결과에는 승/패/무, 점수, 경기 시간, 출전 선수 수, 경기장, 경기 날짜 등 상세 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->