### PR TITLE
[MAT-239] warning 팀 스토어에 집계되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
@@ -76,6 +76,7 @@ public class MatchScoreResponse {
             case OFFSIDE -> score.upOffsideCount();
             case YELLOW_CARD -> score.upWarningCount();
             case RED_CARD -> score.upWarningCount();
+            case WARNING -> score.upWarningCount();
             case OWN_GOAL -> score.upOwnGoalCount();
         }
     }


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-239

## Overview

- updateScore 메소드 switch case 에서 WARNING이 빠져있던 부분 수정하였습니다 






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 경기 이벤트 유형이 'WARNING'일 때도 경고 수가 올바르게 집계되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->