### PR TITLE
[MAT-240] 메모 동기화 webSocket 메시지 보내기

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchMemoResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchMemoResponse.java
@@ -1,6 +1,7 @@
 package com.matchday.matchdayserver.match.model.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,8 +9,12 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
 @Schema(description = "매치별 메모 응답 객체")
 public class MatchMemoResponse {
+
+    @Schema(description = "메모id")
+    private Long matchId;
 
     @Schema(description = "메모", nullable = true)
     private String memo;

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -19,6 +19,7 @@ import com.matchday.matchdayserver.match.model.dto.response.MatchMemoResponse;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import java.time.LocalTime;
 import java.util.List;
@@ -30,6 +31,7 @@ public class MatchService {
   private final MatchRepository matchRepository;
   private final MatchScoreService matchScoreService;
     private final TeamRepository teamRepository;
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     public MatchInfoResponse getMatchInfo(Long matchId) {
     Match match = matchRepository.findById(matchId)
@@ -44,6 +46,11 @@ public class MatchService {
 
     match.updateMemo(request.getMemo());
     matchRepository.save(match);
+      MatchMemoResponse response = MatchMemoResponse.builder().
+          matchId(match.getId()).
+          memo(match.getMemo()).
+          build();
+      simpMessagingTemplate.convertAndSend("/topic/match-memo", response);
   }
 
   public MatchMemoResponse get(Long matchId) {


### PR DESCRIPTION
## Related Issue

Related to : 해당 커밋에 관련된 이슈 번호

## Overview

- 이제 /matches/createOrUpdate 요청시 "/topic/match-memo" 로 

```json
matchId
: 1
memo
: "수정된메모내용"
```
websocket 메시지를 보냅니다

## Screenshot

![image](https://github.com/user-attachments/assets/5a91f566-8ebc-4b4e-9dbd-fd0359e372ac)







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 매치 메모가 생성 또는 수정될 때 실시간으로 `/topic/match-memo` 채널을 통해 메모 정보가 전송됩니다.

- **기타**
  - 응답 데이터에 matchId 필드가 추가되어 더 많은 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->