### PR TITLE
[MAT-245] memo 동기화 websocket 엔드포인트 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -16,6 +16,7 @@ import com.matchday.matchdayserver.match.model.mapper.MatchMapper;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
 import com.matchday.matchdayserver.match.model.dto.request.MatchMemoRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchMemoResponse;
+import com.matchday.matchdayserver.matchevent.common.MatchEventConstants;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +51,11 @@ public class MatchService {
           matchId(match.getId()).
           memo(match.getMemo()).
           build();
-      simpMessagingTemplate.convertAndSend("/topic/match-memo", response);
+
+      simpMessagingTemplate.convertAndSend(
+          MatchEventConstants.getMemoUrl(matchId),
+          response
+      );
   }
 
   public MatchMemoResponse get(Long matchId) {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/common/MatchEventConstants.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/common/MatchEventConstants.java
@@ -7,5 +7,5 @@ public class MatchEventConstants {
         return MATCH_URL_PREFIX  + matchId;
     }
 
-    public static String getMemoTopic(Long matchId) { return MATCH_URL_PREFIX  + matchId + "/memo"; }
+    public static String getMemoUrl(Long matchId) { return MATCH_URL_PREFIX  + matchId + "/memo"; }
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/common/MatchEventConstants.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/common/MatchEventConstants.java
@@ -1,9 +1,11 @@
 package com.matchday.matchdayserver.matchevent.common;
 
 public class MatchEventConstants {
-    public static final String MATCH_EVENT_URL_PREFIX = "/topic/match/";
+    public static final String MATCH_URL_PREFIX  = "/topic/match/";
 
     public static String getMatchEventUrl(Long matchId) {
-        return MATCH_EVENT_URL_PREFIX + matchId;
+        return MATCH_URL_PREFIX  + matchId;
     }
+
+    public static String getMemoTopic(Long matchId) { return MATCH_URL_PREFIX  + matchId + "/memo"; }
 }


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-245

## Overview

- memo 동기화 websocket 엔드포인트 변경

/topic/match-memo
에서
/topic/match/{matchId}/memo

## Screenshot

![image](https://github.com/user-attachments/assets/4e41a846-b0b2-4912-a16f-70515246e0b4)







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 경기 메모 업데이트 시 WebSocket 메시지가 경기별로 구분된 동적 채널로 전송됩니다.

- **버그 수정**
  - 고정된 토픽 대신, 경기 ID에 따라 동적으로 생성되는 토픽으로 메시지가 전송됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->