### PR TITLE
[MAT-247] 매치 생성시 매치 상태 입력 받지 않도록 수정

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchCreateRequest.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/request/MatchCreateRequest.java
@@ -62,8 +62,4 @@ public class MatchCreateRequest {
 
     @Schema(description = "대기심", example = "정대기", nullable = true)
     private String fourthReferee;
-
-    @NotNull
-    @Schema(description = "경기 상태 (SCHEDULED, ONGOING, FINISHED)", example = "SCHEDULED")
-    private MatchState matchState;
 }

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -120,7 +120,7 @@ public class Match {
     public Match(String title, Team homeTeam, Team awayTeam, MatchType matchType, String stadium, LocalDate matchDate,
         LocalTime plannedStartTime, LocalTime plannedEndTime, LocalTime firstHalfStartTime, LocalTime firstHalfEndTime,
         LocalTime secondHalfStartTime, LocalTime secondHalfEndTime, String mainRefereeName,
-        String assistantReferee1, String assistantReferee2, String fourthReferee, MatchState matchState,
+        String assistantReferee1, String assistantReferee2, String fourthReferee,
         Integer firstHalfPeriod, Integer secondHalfPeriod) {
 
         this.title = title;
@@ -139,7 +139,7 @@ public class Match {
         this.assistantReferee1 = assistantReferee1;
         this.assistantReferee2 = assistantReferee2;
         this.fourthReferee = fourthReferee;
-        this.matchState = matchState;
+        this.matchState = MatchState.SCHEDULED; //매치 생성시 "SCHEDULED" 기본 값으로 설정
         this.firstHalfPeriod = firstHalfPeriod;
         this.secondHalfPeriod = secondHalfPeriod;
     }

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchCreateService.java
@@ -51,7 +51,6 @@ public class MatchCreateService {
                 .assistantReferee1(request.getAssistantReferee1())
                 .assistantReferee2(request.getAssistantReferee2())
                 .fourthReferee(request.getFourthReferee())
-                .matchState(request.getMatchState())
                 .firstHalfPeriod(request.getFirstHalfPeriod())
                 .secondHalfPeriod(request.getSecondHalfPeriod())
                 .build();


### PR DESCRIPTION
## Related Issue
[MAT-247](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-247)

## Overview
- 매치 생성시 매치 상태(MatchState) 입력 받지 않고, 자동으로 'SCHEDULED(경기전)' 이 되도록 수정했습니다.

## Screenshot
<img width="404" alt="스크린샷 2025-05-20 오후 3 36 57" src="https://github.com/user-attachments/assets/cf8b084a-a07f-43e7-8069-6eae3219fa12" />
<img width="628" alt="스크린샷 2025-05-20 오후 3 37 53" src="https://github.com/user-attachments/assets/03480df0-156b-4308-9880-ac0f7271602e" />





