### PR TITLE
[MAT-246] 진행 중 경기에만 이벤트 발생시킬 수 있도록 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/MatchStatus.java
@@ -20,7 +20,8 @@ public enum MatchStatus implements StatusInterface {
     NOTFOUND_MATCH_EVENT(404, 6017, "존재하지 않는 경기 이벤트입니다"),
     INVALID_HALF_PERIOD(404,6018,"유효한 경기 기간은 1분~45분입니다"),
     INVALID_PAGE_NUMBER(400, 6019, "page는 음수 값이 될 수 없습니다."),
-    INVALID_PAGE_SIZE(400, 6020, "size는 1이상의 값이어야 합니다.")
+    INVALID_PAGE_SIZE(400, 6020, "size는 1이상의 값이어야 합니다."),
+    NOT_IN_PLAY_MATCH(400,6021,"진행 중인 경기가 아닙니다")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -85,7 +85,7 @@ public class Match {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "match_state", nullable = false)
-    private MatchState matchState;  //경기 상태 (시작 전, 진행 중, 종료)
+    private MatchState matchState;
 
     public enum MatchType {
         리그, 대회, 친선경기

--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -16,6 +16,7 @@ import com.matchday.matchdayserver.match.model.mapper.MatchMapper;
 import com.matchday.matchdayserver.match.repository.MatchRepository;
 import com.matchday.matchdayserver.match.model.dto.request.MatchMemoRequest;
 import com.matchday.matchdayserver.match.model.dto.response.MatchMemoResponse;
+import com.matchday.matchdayserver.match.util.MatchStateValidator;
 import com.matchday.matchdayserver.matchevent.common.MatchEventConstants;
 import com.matchday.matchdayserver.team.repository.TeamRepository;
 import jakarta.transaction.Transactional;
@@ -44,6 +45,8 @@ public class MatchService {
   public void createOrUpdate(Long matchId, MatchMemoRequest request) {
     Match match = matchRepository.findById(matchId)
         .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
+
+      MatchStateValidator.validateInPlay(match);
 
     match.updateMemo(request.getMemo());
     matchRepository.save(match);

--- a/src/main/java/com/matchday/matchdayserver/match/util/MatchStateValidator.java
+++ b/src/main/java/com/matchday/matchdayserver/match/util/MatchStateValidator.java
@@ -10,7 +10,7 @@ public class MatchStateValidator {
     private MatchStateValidator() {} // 유틸클래스니까
 
     public static void validateInPlay(Match match) {
-        if (match.getMatchState().equals(MatchState.IN_PLAY)) {
+        if (!match.getMatchState().equals(MatchState.IN_PLAY)) {
             throw new ApiException(MatchStatus.NOT_IN_PLAY_MATCH);
         }
     }

--- a/src/main/java/com/matchday/matchdayserver/match/util/MatchStateValidator.java
+++ b/src/main/java/com/matchday/matchdayserver/match/util/MatchStateValidator.java
@@ -1,0 +1,17 @@
+package com.matchday.matchdayserver.match.util;
+
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.MatchStatus;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.model.enums.MatchState;
+
+public class MatchStateValidator {
+
+    private MatchStateValidator() {} // 유틸클래스니까
+
+    public static void validateInPlay(Match match) {
+        if (match.getMatchState() != MatchState.IN_PLAY) {
+            throw new ApiException(MatchStatus.NOT_IN_PLAY_MATCH);
+        }
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/match/util/MatchStateValidator.java
+++ b/src/main/java/com/matchday/matchdayserver/match/util/MatchStateValidator.java
@@ -10,7 +10,7 @@ public class MatchStateValidator {
     private MatchStateValidator() {} // 유틸클래스니까
 
     public static void validateInPlay(Match match) {
-        if (match.getMatchState() != MatchState.IN_PLAY) {
+        if (match.getMatchState().equals(MatchState.IN_PLAY)) {
             throw new ApiException(MatchStatus.NOT_IN_PLAY_MATCH);
         }
     }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventCancelService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventCancelService.java
@@ -2,6 +2,10 @@ package com.matchday.matchdayserver.matchevent.service;
 
 import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.MatchStatus;
+import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.model.enums.MatchState;
+import com.matchday.matchdayserver.match.repository.MatchRepository;
+import com.matchday.matchdayserver.match.util.MatchStateValidator;
 import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
@@ -17,8 +21,15 @@ import lombok.RequiredArgsConstructor;
 public class MatchEventCancelService {
 
     private final MatchEventRepository matchEventRepository;
+    private final MatchRepository matchRepository;
 
     public void cancelEvent(Long matchId, MatchEventCancelRequest message) {
+
+        Match match = matchRepository.findById(matchId)
+            .orElseThrow(() -> new ApiException(MatchStatus.NOTFOUND_MATCH));
+
+        MatchStateValidator.validateInPlay(match);
+
         MatchEvent matchEvent;
         MatchEventCancelRequest request = message;
         if (request.getMatchUserId() != null) {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -61,7 +61,7 @@ public class MatchEventSaveService {
         Match match = matchUser.getMatch();
 
         //경기 상태가 진행 중인지 확인
-        if (match.getMatchState() != MatchState.IN_PLAY) {
+        if (!match.getMatchState().equals(MatchState.IN_PLAY)) {
             throw new ApiException(MatchStatus.NOT_IN_PLAY_MATCH);
         }
 

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventSaveService.java
@@ -4,6 +4,8 @@ import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.DefaultStatus;
 import com.matchday.matchdayserver.common.response.MatchStatus;
 import com.matchday.matchdayserver.match.model.entity.Match;
+import com.matchday.matchdayserver.match.model.enums.MatchState;
+import com.matchday.matchdayserver.match.util.MatchStateValidator;
 import com.matchday.matchdayserver.matchevent.common.MatchEventConstants;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventRequest;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
@@ -39,6 +41,9 @@ public class MatchEventSaveService {
 
         Match match = matchUser.getMatch();
 
+        //경기 상태가 진행 중인지 확인
+        MatchStateValidator.validateInPlay(match);
+
         List<MatchEventResponse> matchEventResponse = matchEventStrategy.generateMatchEventLog(
             request, match, matchUser);
         if (!matchEventResponse.isEmpty()) {
@@ -54,6 +59,11 @@ public class MatchEventSaveService {
             .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
 
         Match match = matchUser.getMatch();
+
+        //경기 상태가 진행 중인지 확인
+        if (match.getMatchState() != MatchState.IN_PLAY) {
+            throw new ApiException(MatchStatus.NOT_IN_PLAY_MATCH);
+        }
 
         List<MatchEventResponse> matchEventResponse = matchEventStrategy.generateMatchEventLog(
             request, match, matchUser);

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserExchangeService.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.matchday.matchdayserver.common.response.DefaultStatus;
+import com.matchday.matchdayserver.match.model.enums.MatchState;
+import com.matchday.matchdayserver.match.util.MatchStateValidator;
 import com.matchday.matchdayserver.matchevent.common.MatchEventConstants;
 import com.matchday.matchdayserver.matchevent.mapper.MatchEventMapper;
 import com.matchday.matchdayserver.matchevent.model.dto.MatchEventResponse;
@@ -42,6 +44,9 @@ public class MatchUserExchangeService {
         MatchUser toMatchUser = matchUserRepository
             .findByMatchIdAndMatchUserIdWithFetch(matchId, request.getToMatchUserId())
             .orElseThrow(() -> new ApiException(MatchStatus.NOT_PARTICIPATING_PLAYER));
+
+        //진행 중인 경기인지 확인
+        MatchStateValidator.validateInPlay(fromMatchUser.getMatch());
 
         // Dirty Checking으로 자동 저장
         fromMatchUser.substituteTo(toMatchUser);

--- a/src/main/resources/db/migration/V2__match_state_enum_change.sql
+++ b/src/main/resources/db/migration/V2__match_state_enum_change.sql
@@ -1,0 +1,3 @@
+ALTER TABLE matchday_schema.`match`
+    MODIFY COLUMN match_state ENUM('SCHEDULED', 'IN_PLAY', 'FINISHED')
+    DEFAULT 'SCHEDULED' NOT NULL;

--- a/src/main/resources/db/migration/V2__match_state_enum_change.sql
+++ b/src/main/resources/db/migration/V2__match_state_enum_change.sql
@@ -1,3 +1,3 @@
-ALTER TABLE matchday_schema.`match`
+ALTER TABLE `match`
     MODIFY COLUMN match_state ENUM('SCHEDULED', 'IN_PLAY', 'FINISHED')
     DEFAULT 'SCHEDULED' NOT NULL;

--- a/src/test/java/com/matchday/matchdayserver/IntegrationTestSupport.java
+++ b/src/test/java/com/matchday/matchdayserver/IntegrationTestSupport.java
@@ -1,0 +1,12 @@
+package com.matchday.matchdayserver;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@AutoConfigureMockMvc
+@TestPropertySource(locations = "classpath:application-test.yml")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class IntegrationTestSupport {
+
+}

--- a/src/test/java/com/matchday/matchdayserver/user/controller/UserControllerCreateTest.java
+++ b/src/test/java/com/matchday/matchdayserver/user/controller/UserControllerCreateTest.java
@@ -4,13 +4,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.matchday.matchdayserver.IntegrationTestSupport;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -19,10 +17,7 @@ import com.matchday.matchdayserver.user.model.dto.request.UserCreateRequest;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.repository.UserRepository;
 
-@AutoConfigureMockMvc
-@TestPropertySource(locations = "classpath:application-test.yml")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class UserControllerCreateTest {
+public class UserControllerCreateTest extends IntegrationTestSupport {
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-246

## Overview

- match의 match_state 가 IN_PLAY 가 아닌 경기는 **이벤트저장,메모,교체,취소**가 되지 않도록 수정했습니다

이때 오류 '진행 중인 경기가 아닙니다' 가 발생합니다

## Screenshot

<img width="419" alt="image" src="https://github.com/user-attachments/assets/ae663882-a24c-4b48-a8e9-1007ca0f033d" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 진행 중이 아닌 경기에서 작업 시도 시 "진행 중인 경기가 아닙니다" 오류 메시지가 표시됩니다.
  - 경기 상태 검증 기능이 추가되어, 경기 이벤트 저장, 취소, 교체, 메모 수정 등 주요 작업 시 경기가 반드시 진행 중인지 확인합니다.

- **버그 수정**
  - 경기 이벤트 저장, 취소, 교체, 메모 수정 등 작업에서 경기 상태 검증이 강화되어 비진행 경기에서의 작업이 차단됩니다.

- **데이터베이스**
  - 경기 상태 컬럼이 ENUM 타입으로 변경되어, 'SCHEDULED', 'IN_PLAY', 'FINISHED' 값만 허용됩니다. 기본값은 'SCHEDULED'입니다.

- **테스트**
  - 통합 테스트를 위한 기본 설정 클래스가 추가되어 테스트 환경 구성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->