### PR TITLE
[MAT-251] MatchUser 조회 응답에 자책골 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/entity/Match.java
@@ -84,7 +84,7 @@ public class Match {
     private String memo;  //경기 메모
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "match_state", nullable = false, length = 50, columnDefinition = "VARCHAR(50) DEFAULT 'SCHEDULED'")
+    @Column(name = "match_state", nullable = false)
     private MatchState matchState;  //경기 상태 (시작 전, 진행 중, 종료)
 
     public enum MatchType {

--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventQueryService.java
@@ -19,12 +19,13 @@ public class MatchEventQueryService {
      * <p>
      */
     public MatchUserEventStat getMatchUserEventStat(Long matchId, Long matchUserId) {
-        int goals = 0, assists = 0, yellowCards = 0, redCards = 0, cautions = 0;
+        int goals = 0, ownGoals = 0, assists = 0, yellowCards = 0, redCards = 0, cautions = 0;
 
         List<EventTypeCount> counts = matchEventRepository.countEventTypesByMatchUserAndMatch(matchUserId, matchId);
         for (EventTypeCount c : counts) {
             switch (c.getEventType()) {
                 case GOAL -> goals = c.getCount().intValue();
+                case OWN_GOAL -> ownGoals = c.getCount().intValue();
                 case ASSIST -> assists = c.getCount().intValue();
                 case YELLOW_CARD -> yellowCards = c.getCount().intValue();
                 case RED_CARD -> redCards = c.getCount().intValue();
@@ -34,6 +35,7 @@ public class MatchEventQueryService {
 
         return MatchUserEventStat.builder()
             .goals(goals)
+            .ownGoals(ownGoals)
             .assists(assists)
             .yellowCards(yellowCards)
             .redCards(redCards)

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserEventStat.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Setter
 public class MatchUserEventStat {
     private Integer goals;
+    private Integer ownGoals;
     private Integer assists;
     private Integer yellowCards;
     private Integer redCards;
@@ -15,10 +16,11 @@ public class MatchUserEventStat {
     private boolean sentOff;   // 퇴장 여부
 
     @Builder
-    public MatchUserEventStat(Integer goals, Integer assists,
+    public MatchUserEventStat(Integer goals, Integer ownGoals, Integer assists,
         Integer yellowCards, Integer redCards,
         Integer caution, boolean sentOff) {
         this.goals = goals;
+        this.ownGoals = ownGoals;
         this.assists = assists;
         this.yellowCards = yellowCards;
         this.redCards = redCards;

--- a/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/model/dto/MatchUserResponse.java
@@ -38,6 +38,10 @@ public class MatchUserResponse {
     private Integer goals;
 
     @NotNull
+    @Schema(description = "자책골 수", example = "1")
+    private Integer ownGoals;
+
+    @NotNull
     @Schema(description = "어시스트 수", example = "1")
     private Integer assists;
 
@@ -67,7 +71,7 @@ public class MatchUserResponse {
 
     @Builder
     public MatchUserResponse(Long id, Long userId, String name, Integer number, String matchPosition, Integer matchGrid,
-        Integer goals, Integer assists,
+        Integer goals, Integer ownGoals, Integer assists,
         Integer yellowCards, Integer redCards, Integer caution, boolean sentOff, String profileImg,boolean subIn, boolean subOut) {
         this.id = id;
         this.userId = userId;
@@ -76,6 +80,7 @@ public class MatchUserResponse {
         this.matchPosition = matchPosition;
         this.matchGrid = matchGrid;
         this.goals = goals;
+        this.ownGoals = ownGoals;
         this.assists = assists;
         this.yellowCards = yellowCards;
         this.redCards = redCards;

--- a/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/service/MatchUserService.java
@@ -124,6 +124,7 @@ public class MatchUserService {
                 .matchPosition(matchUser.getMatchPosition())
                 .matchGrid(matchUser.getMatchGrid())
                 .goals(stat.getGoals())
+                .ownGoals(stat.getOwnGoals())
                 .assists(stat.getAssists())
                 .yellowCards(stat.getYellowCards())
                 .redCards(stat.getRedCards())


### PR DESCRIPTION
## Related Issue

[MAT-251](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-251)

## Overview
- MatchUser 조회시 자책골(ownGoals) 조회 될 수 있게 응답 값 추가 했습니다. 

## Screenshot
<img width="451" alt="스크린샷 2025-05-20 오후 9 08 25" src="https://github.com/user-attachments/assets/107a1f70-8db0-407b-a381-3c674c5885f4" />







[MAT-251]: https://match-day.atlassian.net/browse/MAT-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 경기 참가자 정보에 자책골(own goals) 통계가 추가되어, 각 참가자의 자책골 수를 확인할 수 있습니다.

- **버그 수정**
    - 경기 상태(matchState) 필드의 데이터베이스 컬럼 제약 조건이 간소화되었습니다. (기본값 및 길이 제한 제거)

- **문서화**
    - 자책골 필드에 대한 Swagger 문서 설명 및 예시가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->