### PR TITLE
[MAT-255] HALF_TIME 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
+++ b/src/main/java/com/matchday/matchdayserver/match/service/MatchService.java
@@ -145,6 +145,7 @@ public class MatchService {
                         break;
                     case END_TIME:
                         match.setFirstHalfEndTime(halfTimeRequest.getTime());
+                        match.setMatchState(MatchState.HALF_TIME);
                         break;
                 }
                 break;
@@ -153,6 +154,7 @@ public class MatchService {
                 switch (halfTimeRequest.getTimeType()) {
                     case START_TIME:
                         match.setSecondHalfStartTime(halfTimeRequest.getTime());
+                        match.setMatchState(MatchState.IN_PLAY);
                         break;
                     case END_TIME:
                         match.setSecondHalfEndTime(halfTimeRequest.getTime());


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-255

## Overview

- 전반 종료 후 후반 시작전에도 이벤트 등록되지 않게 수정
- 전반 종료 시 match_state를 HALF_TIME으로 변경하고 후반 시작 시 다시 IN_PLAING으로 변경하는 방식으로 해결하였습니다





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 하프타임 및 후반전 시작 시 경기 상태가 올바르게 업데이트되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->