### PR TITLE
[MAT-261] YELLOW_CARD와 RED_CARD는 경고 집계에 포함되지 않도록 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/match/model/dto/response/MatchScoreResponse.java
@@ -74,8 +74,8 @@ public class MatchScoreResponse {
             case CORNER_KICK -> score.upCornerKickCount();
             case FOUL -> score.upFoulCount();
             case OFFSIDE -> score.upOffsideCount();
-            case YELLOW_CARD -> score.upWarningCount();
-            case RED_CARD -> score.upWarningCount();
+            //case YELLOW_CARD -> score.upWarningCount();
+            //case RED_CARD -> score.upWarningCount();
             case WARNING -> score.upWarningCount();
             case OWN_GOAL -> score.upOwnGoalCount();
         }


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-261

## Overview

현재 로직 상 옐로 카드와 레드카드 발생 시 별로도 WARNING 카운트가 증가하므로
- updateScore 메소드에서 YELLOW_CARD와 RED_CARD는 경고 집계에 포함되지 않도록 변경하였습니다







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 옐로우카드(YELLOW_CARD)와 레드카드(RED_CARD) 이벤트 발생 시 경고 수가 더 이상 증가하지 않도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->