### PR TITLE
[MAT-263] 매치 이벤트 오프사이드시 파울+1 되는 로직 삭제

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/service/MatchEventStrategy.java
@@ -90,23 +90,20 @@ public class MatchEventStrategy {
      * 오프사이드 이벤트 기록 시 호출됩니다.
      * <ul>
      * <li>오프사이드 이벤트(offsideEvent)를 생성합니다.</li>
-     * <li>오프사이드 이벤트를 기반으로 파울(foulEvent) 이벤트를 복사 생성합니다.</li>
-     * <li>두 이벤트를 모두 저장하고, 각각의 응답 객체를 반환합니다.</li>
+     * <li>이벤트를 모두 저장하고, 각각의 응답 객체를 반환합니다.</li>
      * </ul>
      *
      * @param request   오프사이드 이벤트 요청 정보
      * @param match     해당 경기 정보
      * @param matchUser 이벤트를 기록한 사용자
-     * @return 생성된 이벤트들의 응답 리스트 (오프사이드, 파울)
+     * @return 생성된 이벤트들의 응답 리스트 (오프사이드)
      */
     private List<MatchEventResponse> generateOffsideEvent(MatchEventRequest request, Match match,
         MatchUser matchUser) {
         MatchEvent offsideEvent = MatchEventMapper.toEntity(request, match, matchUser);
-        MatchEvent foulEvent = offsideEvent.copyWith(MatchEventType.FOUL);
-        matchEventRepository.saveAll(List.of(offsideEvent, foulEvent));
+        matchEventRepository.saveAll(List.of(offsideEvent));
         return List.of(
-            MatchEventMapper.toResponse(offsideEvent),
-            MatchEventMapper.toResponse(foulEvent));
+            MatchEventMapper.toResponse(offsideEvent));
     }
 
     /**


### PR DESCRIPTION
## Related Issue

[MAT-263](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-263)

## Overview
- 매치 이벤트 중 오프사이드 발생시 파울 +1 되는 로직 수정했습니다.

## Screenshot
- 오프사이드 이벤트 발생
<img width="294" alt="스크린샷 2025-05-21 오후 4 33 06" src="https://github.com/user-attachments/assets/9b83f7b9-eaf0-4d02-a5fe-eb506b667ed4" />

- 점수 조회
<img width="865" alt="스크린샷 2025-05-21 오후 4 34 00" src="https://github.com/user-attachments/assets/8f488b3a-6da7-4ead-be8f-fea609063462" />







[MAT-263]: https://match-day.atlassian.net/browse/MAT-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 오프사이드 이벤트 생성 시 더 이상 추가적인 파울 이벤트가 함께 생성되지 않습니다. 이제 오프사이드 이벤트만 생성 및 반환됩니다.
- **문서화**
  - 오프사이드 이벤트 생성 관련 설명이 실제 동작과 일치하도록 문서가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->