### PR TITLE
[MAT-279] 팀 멤버 조회시 누적 출전, 득점, 경고 수 조회 되도록 추가

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -60,4 +60,14 @@ public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
 
     List<MatchEvent> findAllByParentId(Long parentId);
 
+    //누적 골 계산
+    @Query("SELECT COUNT(e) FROM MatchEvent e JOIN MatchUser mu ON e.matchUser.id = mu.id " +
+        "WHERE mu.team.id = :teamId AND mu.user.id = :userId AND e.eventType = 'GOAL'")
+    int countGoalsByTeamIdAndUserId(@Param("teamId") Long teamId, @Param("userId") Long userId);
+
+    //누적 경고 계산
+    @Query("SELECT COUNT(e) FROM MatchEvent e JOIN MatchUser mu ON e.matchUser.id = mu.id " +
+        "WHERE mu.team.id = :teamId AND mu.user.id = :userId AND e.eventType = 'WARNING'")
+    int countWarningsByTeamIdAndUserId(@Param("teamId") Long teamId,
+        @Param("userId") Long userId);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchevent/repository/MatchEventRepository.java
@@ -60,14 +60,7 @@ public interface MatchEventRepository extends JpaRepository<MatchEvent, Long> {
 
     List<MatchEvent> findAllByParentId(Long parentId);
 
-    //누적 골 계산
-    @Query("SELECT COUNT(e) FROM MatchEvent e JOIN MatchUser mu ON e.matchUser.id = mu.id " +
-        "WHERE mu.team.id = :teamId AND mu.user.id = :userId AND e.eventType = 'GOAL'")
-    int countGoalsByTeamIdAndUserId(@Param("teamId") Long teamId, @Param("userId") Long userId);
-
-    //누적 경고 계산
-    @Query("SELECT COUNT(e) FROM MatchEvent e JOIN MatchUser mu ON e.matchUser.id = mu.id " +
-        "WHERE mu.team.id = :teamId AND mu.user.id = :userId AND e.eventType = 'WARNING'")
-    int countWarningsByTeamIdAndUserId(@Param("teamId") Long teamId,
-        @Param("userId") Long userId);
+    //이벤트별 누적 값 계산
+    @Query("SELECT COUNT(e) FROM MatchEvent e JOIN MatchUser mu ON e.matchUser.id = mu.id " + "WHERE mu.team.id = :teamId AND mu.user.id = :userId AND e.eventType = :eventType")
+    int countEventsByTeamIdAndUserIdAndEventType(@Param("teamId") Long teamId, @Param("userId") Long userId, @Param("eventType") MatchEventType eventType);
 }

--- a/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
+++ b/src/main/java/com/matchday/matchdayserver/matchuser/repository/MatchUserRepository.java
@@ -44,4 +44,16 @@ public interface MatchUserRepository extends JpaRepository<MatchUser, Long> {
     // 특정 경기의 모든 MatchUser 조회
     List<MatchUser> findByMatchId(Long matchId);
 
+    @Query(value = """
+    SELECT COUNT(*) FROM match_user mu
+    LEFT JOIN match_event me 
+        ON mu.id = me.match_user_id AND me.event_type = 'SUB_IN'
+    WHERE mu.team_id = :teamId
+    AND mu.user_id = :userId
+    AND (
+        mu.role = 'START_PLAYER' OR 
+        (mu.role = 'SUB_PLAYER' AND me.id IS NOT NULL)
+    )
+""", nativeQuery = true)
+    int countAppearances(@Param("teamId") Long teamId, @Param("userId") Long userId);
 }

--- a/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/team/model/dto/response/TeamMemberResponse.java
@@ -31,13 +31,25 @@ public class TeamMemberResponse {
     @Schema(description = "프로필 이미지", nullable = true)
     private String imageUrl; //프로필 이미지 url
 
+    @Schema(description = "누적 출전수")
+    private int totalAppearances;
+
+    @Schema(description = "누적 득점수")
+    private int totalGoals;
+
+    @Schema(description = "누적 경고수")
+    private int totalWarnings;
+
     @Builder
-    public TeamMemberResponse(Long id, String name, Integer number, String defaultPosition, Boolean isActive,String imageUrl) {
+    public TeamMemberResponse(Long id, String name, Integer number, String defaultPosition, Boolean isActive,String imageUrl, int totalAppearances, int totalGoals, int totalWarnings) {
         this.id = id;
         this.name = name;
         this.number = number;
         this.defaultPosition = defaultPosition;
         this.isActive = isActive;
         this.imageUrl = imageUrl;
+        this.totalAppearances = totalAppearances;
+        this.totalGoals = totalGoals;
+        this.totalWarnings = totalWarnings;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
+++ b/src/main/java/com/matchday/matchdayserver/team/service/TeamService.java
@@ -2,6 +2,7 @@ package com.matchday.matchdayserver.team.service;
 
 import com.matchday.matchdayserver.common.exception.ApiException;
 import com.matchday.matchdayserver.common.response.TeamStatus;
+import com.matchday.matchdayserver.matchevent.model.enums.MatchEventType;
 import com.matchday.matchdayserver.matchevent.repository.MatchEventRepository;
 import com.matchday.matchdayserver.matchuser.repository.MatchUserRepository;
 import com.matchday.matchdayserver.team.model.dto.request.TeamCreateRequest;
@@ -80,9 +81,10 @@ public class TeamService {
             Long userId = userTeam.getUser().getId();
 
             int appearances = matchUserRepository.countAppearances(teamId, userId);
-            int goals = matchEventRepository.countGoalsByTeamIdAndUserId(teamId, userId);
-            int warnings = matchEventRepository.countWarningsByTeamIdAndUserId(
-                teamId, userId);
+            int goals = matchEventRepository.countEventsByTeamIdAndUserIdAndEventType(teamId,userId,
+                MatchEventType.GOAL);
+            int warnings = matchEventRepository.countEventsByTeamIdAndUserIdAndEventType(teamId,userId,
+                MatchEventType.WARNING);
 
             return UserTeamMapper.toTeamMemberResponse(userTeam, appearances, goals, warnings);
         }).collect(Collectors.toList());

--- a/src/main/java/com/matchday/matchdayserver/userteam/model/mapper/UserTeamMapper.java
+++ b/src/main/java/com/matchday/matchdayserver/userteam/model/mapper/UserTeamMapper.java
@@ -1,6 +1,5 @@
 package com.matchday.matchdayserver.userteam.model.mapper;
 
-import com.matchday.matchdayserver.team.model.dto.response.TeamMemberListResponse;
 import com.matchday.matchdayserver.team.model.dto.response.TeamMemberResponse;
 import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.userteam.model.dto.JoinUserTeamResponse;
@@ -18,15 +17,21 @@ public class UserTeamMapper {
                 .build();
     }
     //userTeam -> TeamMember Response 변환 정적 메소드
-    public static TeamMemberResponse toTeamMemberResponse(UserTeam userTeam) {
+    public static TeamMemberResponse toTeamMemberResponse(UserTeam userTeam,
+        int totalAppearances,
+        int totalGoals,
+        int totalWarnings) {
         User user = userTeam.getUser();
         return TeamMemberResponse.builder()
-                .id(user.getId())
-                .name(user.getName())
-                .number(userTeam.getNumber())
-                .defaultPosition(userTeam.getDefaultPosition())
-                .isActive(userTeam.getIsActive())
-                .imageUrl(user.getProfileImg())
-                .build();
+            .id(user.getId())
+            .name(user.getName())
+            .number(userTeam.getNumber())
+            .defaultPosition(userTeam.getDefaultPosition())
+            .isActive(userTeam.getIsActive())
+            .imageUrl(user.getProfileImg())
+            .totalAppearances(totalAppearances)
+            .totalGoals(totalGoals)
+            .totalWarnings(totalWarnings)
+            .build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,8 +36,7 @@ spring:
 springdoc:
     api-docs:
         version: "openapi_3_0"
-        #url: "https://dev-api.matchday-planner.com"
-        url : "http://localhost:8080"
+        url: "https://dev-api.matchday-planner.com"
 
 decorator:
     datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,9 +36,16 @@ spring:
 springdoc:
     api-docs:
         version: "openapi_3_0"
-        url: "https://dev-api.matchday-planner.com"
+        #url: "https://dev-api.matchday-planner.com"
+        url : "http://localhost:8080"
 
 decorator:
     datasource:
         p6spy:
             enable-logging: false
+
+logging:
+    level:
+        org.springframework.messaging: DEBUG
+        org.springframework.web.socket: DEBUG
+        org.springframework.web.socket.messaging: DEBUG


### PR DESCRIPTION
## Related Issue

[MAT-279](https://match-day.atlassian.net/jira/software/projects/MAT/boards/2)

## Overview
- 팀 멤버 조회시 멤버별 누적 출전 수, 득점 수, 경고 수 조회 되도록 추가 구현했습니다.

## Screenshot
<img width="480" alt="스크린샷 2025-05-27 오후 7 10 34" src="https://github.com/user-attachments/assets/aea6b186-fa72-4684-9993-cad13e973641" />






[MAT-279]: https://match-day.atlassian.net/browse/MAT-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 팀원 목록 조회 시 각 팀원의 총 출전 수, 총 득점 수, 총 경고 수가 함께 제공됩니다.

- **기타**
	- Spring 메시징 및 WebSocket 관련 디버그 로그가 활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->