### PR TITLE
[MAT-312] Jwt 리프레시 토큰 적용

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/auth/model/dto/enums/JwtTokenType.java
+++ b/src/main/java/com/matchday/matchdayserver/auth/model/dto/enums/JwtTokenType.java
@@ -1,0 +1,6 @@
+package com.matchday.matchdayserver.auth.model.dto.enums;
+
+public enum JwtTokenType {
+    ACCESS,
+    REFRESH
+}

--- a/src/main/java/com/matchday/matchdayserver/auth/model/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/auth/model/dto/response/OauthLoginResponse.java
@@ -1,6 +1,5 @@
 package com.matchday.matchdayserver.auth.model.dto.response;
 
-import jakarta.servlet.http.Cookie;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,6 +9,5 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class OauthLoginResponse {
     String accessToken; //서버 access token
-    Cookie refreshTokenCookie; //서버 refresh token 쿠키 변환값
     Long id;
 }

--- a/src/main/java/com/matchday/matchdayserver/auth/model/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/auth/model/dto/response/OauthLoginResponse.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.auth.model.dto.response;
 
+import jakarta.servlet.http.Cookie;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class OauthLoginResponse {
-    String token; //서버 access token
+    String accessToken; //서버 access token
+    Cookie refreshTokenCookie; //서버 refresh token 쿠키 변환값
     Long id;
 }

--- a/src/main/java/com/matchday/matchdayserver/auth/model/dto/response/RenewResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/auth/model/dto/response/RenewResponse.java
@@ -1,0 +1,12 @@
+package com.matchday.matchdayserver.auth.model.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RenewResponse {
+    String accessToken; //재발급 받은 서버 access token
+}

--- a/src/main/java/com/matchday/matchdayserver/auth/service/GoogleOauthService.java
+++ b/src/main/java/com/matchday/matchdayserver/auth/service/GoogleOauthService.java
@@ -25,6 +25,9 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class GoogleOauthService {
+
+    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+
     @Value("${oauth.google.client-id}")
     private String googleClientId;
 
@@ -61,7 +64,7 @@ public class GoogleOauthService {
         String jwtAccessToken=jwtTokenProvider.createToken(user.getEmail(), payload, JwtTokenType.ACCESS);
         String jwtRefreshToken=jwtTokenProvider.createToken(user.getEmail(), payload, JwtTokenType.REFRESH);
 
-        return new OauthLoginResponse(jwtAccessToken, createCookie("refreshToken",jwtRefreshToken), user.getId());
+        return new OauthLoginResponse(jwtAccessToken, createCookie(REFRESH_TOKEN_COOKIE_NAME,jwtRefreshToken), user.getId());
     }
 
     private Cookie createCookie(String key, String value) {

--- a/src/main/java/com/matchday/matchdayserver/auth/service/GoogleOauthService.java
+++ b/src/main/java/com/matchday/matchdayserver/auth/service/GoogleOauthService.java
@@ -26,56 +26,33 @@ import java.util.Map;
 @Slf4j
 public class GoogleOauthService {
 
-    public static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
-
     @Value("${oauth.google.client-id}")
     private String googleClientId;
-
     @Value("${oauth.google.client-secret}")
     private String googleClientSecret;
-
     @Value("${oauth.google.redirect-url}")
     private String googleRedirectUri;
 
     private final UserRepository userRepository;
-    private final JwtTokenProvider jwtTokenProvider;
 
     /**
-     * Google OAuth 로그인 처리
+     * REST API 방식 Google OAuth 로그인 처리
      * 1. 인가 코드로 Google Access Token 요청
      * 2. Google Access Token으로 사용자 정보 조회
      * 3. 기존 유저 조회 or 신규 유저 생성
-     * 4. JWT 토큰 발급 및 반환 <- 이것이 스프링 서버 Access Token
+     * 4. User 객체 반환
      */
-    public OauthLoginResponse googleLogin(OauthLoginRequest oAuthLoginRequest) {
+    public User googleLogin(OauthLoginRequest oAuthLoginRequest) {
+        // 인가 코드로 Google Access Token 요청
         GoogleAccessTokenResponse googleAccessToken = getAccessToken(oAuthLoginRequest.getCode());
+        // Google Access Token으로 사용자 정보 조회
         GoogleProfileResponse googleProfile = getProfile(googleAccessToken.getAccess_token());
-        //유저 가져오기
+        // 기존 유저 조회 or 신규 유저 생성
         User user = userRepository.findBySocialId(googleProfile.getSub());
-        //없으면 만들기
         if (user == null) {
             user = createOatuh(googleProfile, SocialType.GOOGLE);
         }
-        //토큰발급
-        Map<String, Object> payload = new HashMap<>();
-        payload.put("userId", user.getId());
-        payload.put("role", user.getRole());
-
-        String jwtAccessToken=jwtTokenProvider.createToken(user.getEmail(), payload, JwtTokenType.ACCESS);
-        String jwtRefreshToken=jwtTokenProvider.createToken(user.getEmail(), payload, JwtTokenType.REFRESH);
-
-        return new OauthLoginResponse(jwtAccessToken, createCookie(REFRESH_TOKEN_COOKIE_NAME,jwtRefreshToken), user.getId());
-    }
-
-    private Cookie createCookie(String key, String value) {
-
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(24*60*60);
-        cookie.setSecure(false); //https (운영환경에선)false
-        cookie.setPath("/"); //전체 경로에 대해 쿠키 유효
-        cookie.setHttpOnly(true);
-
-        return cookie;
+        return user;
     }
 
     /**
@@ -102,7 +79,7 @@ public class GoogleOauthService {
     }
 
     /**
-     * Access Token을 사용하여 Google 사용자 프로필 조회
+     * 구글 Access Token을 사용하여 Google 사용자 프로필 조회
      */
     private GoogleProfileResponse getProfile(String accessToken) {
         RestClient restClient = RestClient.create();

--- a/src/main/java/com/matchday/matchdayserver/common/auth/JwtTokenFilter.java
+++ b/src/main/java/com/matchday/matchdayserver/common/auth/JwtTokenFilter.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.common.auth;
 
+import com.matchday.matchdayserver.auth.model.dto.enums.JwtTokenType;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.FilterChain;
@@ -43,7 +44,7 @@ public class JwtTokenFilter extends GenericFilter{
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;//HTTP 전용 메소드를 사용하기 위해 변환
         //토큰 형식 검증(Bearer)
         String jwtToken =resolveToken(httpServletRequest);
-        if(StringUtils.hasText(jwtToken) && tokenHelper.validateToken(jwtToken)){
+        if(StringUtils.hasText(jwtToken) && tokenHelper.validateToken(jwtToken, JwtTokenType.ACCESS)){
             //문제가 없으면 SecurityContextHolder 에 jwtToken 정보가 담긴 authentication 적재
             Authentication authentication = tokenHelper.getAuthentication(jwtToken);
             UserDetails userDetails = (UserDetails) authentication.getPrincipal();//UserDetails를 구현한 사용자 객체를 Return
@@ -60,7 +61,6 @@ public class JwtTokenFilter extends GenericFilter{
         if (StringUtils.hasText(token) && token.startsWith(BEARER_PREFIX)) {
             return token.substring(BEARER_PREFIX.length());
         }
-
         return null;
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/common/auth/JwtTokenProvider.java
+++ b/src/main/java/com/matchday/matchdayserver/common/auth/JwtTokenProvider.java
@@ -1,11 +1,15 @@
 package com.matchday.matchdayserver.common.auth;
 
+import com.matchday.matchdayserver.auth.model.dto.enums.JwtTokenType;
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.JwtStatus;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.Jwts.SIG;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import org.flywaydb.core.internal.parser.TokenType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
@@ -17,29 +21,38 @@ import java.util.Map;
 @Component
 public class JwtTokenProvider {
     private final SecretKey secretKey;
-    private final int expiration;
+    private static final long ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000L * 60 * 10 ; // 10min
+    private static final long REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS = 1000L * 60 * 60 * 24; // 1d
 
-    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey,@Value("${jwt.expiration}") final int expiration) {
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
         this.secretKey = generateSecretKey(secretKey);
-        this.expiration = expiration;
     }
 
     //토큰 만들기
     //todo:payload에 롤값 넣기
-    public String createToken(String subject, Map<String, ?> payload) {
+    public String createToken(String subject, Map<String, ?> payload, JwtTokenType type) {
         //jwt토큰의 payload는 여러개의 claims 집합
-        Claims claims= generateClaims(subject, payload);
+        Claims claims=null;
+        if(type==JwtTokenType.ACCESS){
+            claims= generateClaims(subject, payload,ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS);
+
+        } else if (type==JwtTokenType.REFRESH){
+            claims=generateClaims(subject, payload,REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS);
+        } else {
+            throw new ApiException(JwtStatus.INVALID_TOKEN_TYPE);
+        }
 
         String token=Jwts.builder() //시그니처 부분 만들기
             .claims(claims)
+            .claim("tokenType", type)
             .signWith(secretKey,Jwts.SIG.HS256)
             .compact();
         return token;
     }
 
-    private Claims generateClaims(String subject, Map<String, ?> payload) {
+    private Claims generateClaims(String subject, Map<String, ?> payload, Long expiration) {
         Date now = new Date();//발행시간
-        Date expirationAt = new Date(now.getTime()+expiration*60*1000L);//gettime은 밀리초 단위이므로 분으로 변경하기
+        Date expirationAt = new Date(now.getTime()+expiration);//gettime은 밀리초 단위이므로 분으로 변경하기
         Claims claims = Jwts.claims()
             .subject(subject)
             .issuedAt(now)

--- a/src/main/java/com/matchday/matchdayserver/common/auth/JwtTokenProvider.java
+++ b/src/main/java/com/matchday/matchdayserver/common/auth/JwtTokenProvider.java
@@ -1,21 +1,17 @@
 package com.matchday.matchdayserver.common.auth;
 
 import com.matchday.matchdayserver.auth.model.dto.enums.JwtTokenType;
-import com.matchday.matchdayserver.common.exception.ApiException;
-import com.matchday.matchdayserver.common.response.JwtStatus;
+import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.user.model.enums.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.Jwts.SIG;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import org.flywaydb.core.internal.parser.TokenType;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
-import java.security.Key;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Map;
 
 @Component
@@ -28,38 +24,42 @@ public class JwtTokenProvider {
         this.secretKey = generateSecretKey(secretKey);
     }
 
-    //토큰 만들기
-    //todo:payload에 롤값 넣기
-    public String createToken(String subject, Map<String, ?> payload, JwtTokenType type) {
-        //jwt토큰의 payload는 여러개의 claims 집합
-        Claims claims=null;
-        if(type==JwtTokenType.ACCESS){
-            claims= generateClaims(subject, payload,ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS);
+    public String createToken(User user, JwtTokenType type) {
 
-        } else if (type==JwtTokenType.REFRESH){
-            claims=generateClaims(subject, payload,REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS);
-        } else {
-            throw new ApiException(JwtStatus.INVALID_TOKEN_TYPE);
-        }
+        Claims claims = generateClaims(user, type);
 
-        String token=Jwts.builder() //시그니처 부분 만들기
+        return Jwts.builder() //시그니처 부분 만들기
             .claims(claims)
             .claim("tokenType", type)
             .signWith(secretKey,Jwts.SIG.HS256)
             .compact();
-        return token;
     }
 
-    private Claims generateClaims(String subject, Map<String, ?> payload, Long expiration) {
+    private Claims generateClaims(User user,JwtTokenType type) {
+
+        Long userId = user.getId();
+        String email = user.getEmail();
+        Role role = user.getRole();
+
+        String subject=email;
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("userId", userId);
+        payload.put("role", role);
+
         Date now = new Date();//발행시간
-        Date expirationAt = new Date(now.getTime()+expiration);//gettime은 밀리초 단위이므로 분으로 변경하기
-        Claims claims = Jwts.claims()
+        long expiration = switch (type) {
+            case ACCESS -> ACCESS_TOKEN_EXPIRE_TIME_IN_MILLISECONDS;
+            case REFRESH -> REFRESH_TOKEN_EXPIRE_TIME_IN_MILLISECONDS;
+        };
+        Date expirationAt = new Date(now.getTime()+expiration);
+
+        return Jwts.claims()
             .subject(subject)
             .issuedAt(now)
             .expiration(expirationAt)
             .add(payload)
             .build();
-        return claims;
     }
 
     //salt(secret)을 이용해 만들어진 Key 로 Jwt의 signature 만듦

--- a/src/main/java/com/matchday/matchdayserver/common/auth/TokenHelper.java
+++ b/src/main/java/com/matchday/matchdayserver/common/auth/TokenHelper.java
@@ -32,13 +32,9 @@ import java.util.*;
 public class TokenHelper {
 
     private final SecretKey secretKey;//SecretKey가 Key보다 하위 인터페이스
-    private final JwtTokenProvider jwtTokenProvider;
-    private final UserRepository userRepository;
 
-    public TokenHelper(@Value("${jwt.secret}") String secretKey, JwtTokenProvider jwtTokenProvider,UserRepository userRepository) {
-        this.jwtTokenProvider=jwtTokenProvider;
+    public TokenHelper(@Value("${jwt.secret}") String secretKey) {
         this.secretKey = generateSecretKey(secretKey);
-        this.userRepository = userRepository;
     }
 
     private SecretKey generateSecretKey(String secret) {
@@ -50,7 +46,8 @@ public class TokenHelper {
     public boolean validateToken(String token, JwtTokenType type) {
         try{
             Claims claims= getClaims(token);
-            if (type!=claims.get("tokenType", JwtTokenType.class)){
+            String tokenTypeStr = claims.get("tokenType", String.class);
+            if (!type.name().equals(tokenTypeStr)) {
                 throw new ApiException(JwtStatus.INVALID_TOKEN_TYPE);
             }
             return true;

--- a/src/main/java/com/matchday/matchdayserver/common/auth/TokenHelper.java
+++ b/src/main/java/com/matchday/matchdayserver/common/auth/TokenHelper.java
@@ -94,40 +94,4 @@ public class TokenHelper {
             .parseSignedClaims(token)//검증할 토큰 전달
             .getPayload();
     }
-
-    public RenewResponse renew(HttpServletRequest request){
-        //리프레시 토큰 가져와서 토큰 있는지 확인
-        String refresh = null;
-        Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals(GoogleOauthService.REFRESH_TOKEN_COOKIE_NAME)) {
-                refresh = cookie.getValue();
-            }
-        }
-
-        if (refresh == null) {
-            throw new ApiException(JwtStatus.NOTFOUND_TOKEN_IN_COOKIE);
-        }
-
-        //리프레시 토큰이 유효한지 검증
-        validateToken(refresh,JwtTokenType.REFRESH);
-
-        //JWT 만들어 리턴해주기
-        Claims claims = getClaims(refresh);
-
-        Map<String, Object> payload = new HashMap<>();
-        Long userId = Long.valueOf(claims.get("userId").toString());
-        String email = claims.getSubject();
-        String role = claims.get("role").toString();
-        payload.put("userId", userId);
-        payload.put("role", role);
-
-        //DB 조회로 사용자 상태 검증
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new ApiException(JwtStatus.NOTFOUND_USER));
-
-        String jwtAccessToken=jwtTokenProvider.createToken(email, payload, JwtTokenType.ACCESS);
-
-        return new RenewResponse(jwtAccessToken);
-    }
 }

--- a/src/main/java/com/matchday/matchdayserver/common/response/JwtStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/JwtStatus.java
@@ -10,7 +10,9 @@ public enum JwtStatus implements StatusInterface {
     INVALID_TOKEN(401, 9006, "유효하지 않은 JWT 토큰"),
     INVALID_TOKEN_TYPE(400,9007,"적절한 토큰 타입이 아닙니다(ACCESS,REFRESH)"),
     NOTFOUND_TOKEN_IN_COOKIE(404,9008,"쿠키에서 토큰값을 찾을 수 없습니다"),
-    NOTFOUND_USER(404,9009,"토큰 페이로드 정보로 찾을 수 없는 사용자 입니다.")
+    NOTFOUND_USER(404,9009,"토큰 페이로드 정보로 찾을 수 없는 사용자 입니다."),
+    NOTFOUND_COOKIE(404,9008,"쿠키에 데이터가 없습니다"),
+
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/common/response/JwtStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/JwtStatus.java
@@ -3,11 +3,14 @@ package com.matchday.matchdayserver.common.response;
 public enum JwtStatus implements StatusInterface {
     UNAUTHORIZED(401, 9000, "JWT 토큰 검증 실패"),
     INVALID_AUTHORIZATION_HEADER(401, 9001, "올바른 Bearer 형식이 아님, Bearer(공백) 총 7자"),
-    EXPIRED_TOKEN(401, 9002, "JWT 토큰이 만료됨"),
-    SIGNATURE_NOT_MATCH(401, 9003, "JWT 서명이 적절하지 않음"),
-    MALFORMED_TOKEN(401, 9004, "JWT 형식이 잘못됨"),
-    INVALID_TOKEN(401, 9005, "유효하지 않은 JWT 토큰"),
-    INVALID_TOKEN_TYPE(400,9006,"적절한 토큰 타입이 아닙니다")
+    EXPIRED_ACCESS_TOKEN(401, 9002, "JWT 엑세스 토큰이 만료됨"),
+    EXPIRED_REFRESH_TOKEN(401, 9003, "JWT 리프레시 토큰이 만료됨"),
+    SIGNATURE_NOT_MATCH(401, 9004, "JWT 서명이 적절하지 않음"),
+    MALFORMED_TOKEN(401, 9005, "JWT 형식이 잘못됨"),
+    INVALID_TOKEN(401, 9006, "유효하지 않은 JWT 토큰"),
+    INVALID_TOKEN_TYPE(400,9007,"적절한 토큰 타입이 아닙니다(ACCESS,REFRESH)"),
+    NOTFOUND_TOKEN_IN_COOKIE(404,9008,"쿠키에서 토큰값을 찾을 수 없습니다"),
+    NOTFOUND_USER(404,9009,"토큰 페이로드 정보로 찾을 수 없는 사용자 입니다.")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/common/response/JwtStatus.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/JwtStatus.java
@@ -6,7 +6,8 @@ public enum JwtStatus implements StatusInterface {
     EXPIRED_TOKEN(401, 9002, "JWT 토큰이 만료됨"),
     SIGNATURE_NOT_MATCH(401, 9003, "JWT 서명이 적절하지 않음"),
     MALFORMED_TOKEN(401, 9004, "JWT 형식이 잘못됨"),
-    INVALID_TOKEN(401, 9005, "유효하지 않은 JWT 토큰")
+    INVALID_TOKEN(401, 9005, "유효하지 않은 JWT 토큰"),
+    INVALID_TOKEN_TYPE(400,9006,"적절한 토큰 타입이 아닙니다")
     ;
 
     private final int httpStatusCode;

--- a/src/main/java/com/matchday/matchdayserver/user/controller/UserOpenApiController.java
+++ b/src/main/java/com/matchday/matchdayserver/user/controller/UserOpenApiController.java
@@ -5,13 +5,13 @@ import com.matchday.matchdayserver.auth.model.dto.response.OauthLoginResponse;
 import com.matchday.matchdayserver.auth.model.dto.response.RenewResponse;
 import com.matchday.matchdayserver.auth.service.GoogleOauthService;
 import com.matchday.matchdayserver.common.response.ApiResponse;
+import com.matchday.matchdayserver.user.model.dto.response.LoginResponse;
+import com.matchday.matchdayserver.user.model.entity.User;
 import com.matchday.matchdayserver.user.service.UserOpenApiService;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,15 +26,17 @@ public class UserOpenApiController {
     private final GoogleOauthService googleOauthService;
     private final UserOpenApiService userOpenApiService;
 
-
     @PostMapping("/google")
     public ApiResponse<OauthLoginResponse> googleLogin(@RequestBody OauthLoginRequest oAuthLoginRequest,HttpServletResponse response){
-        OauthLoginResponse loginResponse = googleOauthService.googleLogin(oAuthLoginRequest);
+        //유저 정보 가져오기
+        User user = googleOauthService.googleLogin(oAuthLoginRequest);
+        //유저 정보로 엑세스토큰과 리프레시 토큰 받아오기
+        LoginResponse loginResponse = userOpenApiService.doLogin(user);
+        //쿠키 세팅
         response.addCookie(loginResponse.getRefreshTokenCookie());
-
+        //엑세스 토큰 리턴
         return ApiResponse.ok(new OauthLoginResponse(
                 loginResponse.getAccessToken(),
-                null, // refreshToken은 쿠키로 보냈으니 null 처리
                 loginResponse.getId()
         ));
     }

--- a/src/main/java/com/matchday/matchdayserver/user/controller/UserOpenApiController.java
+++ b/src/main/java/com/matchday/matchdayserver/user/controller/UserOpenApiController.java
@@ -2,9 +2,12 @@ package com.matchday.matchdayserver.user.controller;
 
 import com.matchday.matchdayserver.auth.model.dto.request.OauthLoginRequest;
 import com.matchday.matchdayserver.auth.model.dto.response.OauthLoginResponse;
+import com.matchday.matchdayserver.auth.model.dto.response.RenewResponse;
 import com.matchday.matchdayserver.auth.service.GoogleOauthService;
 import com.matchday.matchdayserver.common.response.ApiResponse;
+import com.matchday.matchdayserver.user.service.UserOpenApiService;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -18,10 +21,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/open-api/v1/users")
 @RestController
 @RequiredArgsConstructor
-@Slf4j
 public class UserOpenApiController {
 
     private final GoogleOauthService googleOauthService;
+    private final UserOpenApiService userOpenApiService;
 
 
     @PostMapping("/google")
@@ -37,18 +40,7 @@ public class UserOpenApiController {
     }
 
     @PostMapping("/renew")
-    public ApiResponse<?> renewAccessToken(HttpServletRequest request, HttpServletResponse response){
-
-        //리프레시 토큰 가져오기
-
-        //리프레시 토큰 데이터베이스에 있는지 검증
-
-        //리프레시 토큰이 만료되었는지 확인
-
-        //JWT 만들어 리턴해주기
-            return null;
+    public ApiResponse<RenewResponse> renew(HttpServletRequest request){
+        return ApiResponse.ok(userOpenApiService.renewToken(request));
     }
-
-
-
 }

--- a/src/main/java/com/matchday/matchdayserver/user/controller/UserOpenApiController.java
+++ b/src/main/java/com/matchday/matchdayserver/user/controller/UserOpenApiController.java
@@ -5,7 +5,10 @@ import com.matchday.matchdayserver.auth.model.dto.response.OauthLoginResponse;
 import com.matchday.matchdayserver.auth.service.GoogleOauthService;
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,13 +18,37 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/open-api/v1/users")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class UserOpenApiController {
 
     private final GoogleOauthService googleOauthService;
 
+
     @PostMapping("/google")
-    public ApiResponse<OauthLoginResponse> googleLogin(@RequestBody OauthLoginRequest oAuthLoginRequest){
-        return ApiResponse.ok(googleOauthService.googleLogin(oAuthLoginRequest));
+    public ApiResponse<OauthLoginResponse> googleLogin(@RequestBody OauthLoginRequest oAuthLoginRequest,HttpServletResponse response){
+        OauthLoginResponse loginResponse = googleOauthService.googleLogin(oAuthLoginRequest);
+        response.addCookie(loginResponse.getRefreshTokenCookie());
+
+        return ApiResponse.ok(new OauthLoginResponse(
+                loginResponse.getAccessToken(),
+                null, // refreshToken은 쿠키로 보냈으니 null 처리
+                loginResponse.getId()
+        ));
     }
+
+    @PostMapping("/renew")
+    public ApiResponse<?> renewAccessToken(HttpServletRequest request, HttpServletResponse response){
+
+        //리프레시 토큰 가져오기
+
+        //리프레시 토큰 데이터베이스에 있는지 검증
+
+        //리프레시 토큰이 만료되었는지 확인
+
+        //JWT 만들어 리턴해주기
+            return null;
+    }
+
+
 
 }

--- a/src/main/java/com/matchday/matchdayserver/user/model/dto/response/LoginResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/user/model/dto/response/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.matchday.matchdayserver.user.model.dto.response;
+
+import jakarta.servlet.http.Cookie;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    String accessToken; //서버 access token
+    Cookie refreshTokenCookie; //서버 refresh token 쿠키 변환값
+    Long id;
+}

--- a/src/main/java/com/matchday/matchdayserver/user/service/UserOpenApiService.java
+++ b/src/main/java/com/matchday/matchdayserver/user/service/UserOpenApiService.java
@@ -1,0 +1,62 @@
+package com.matchday.matchdayserver.user.service;
+
+import com.matchday.matchdayserver.auth.model.dto.enums.JwtTokenType;
+import com.matchday.matchdayserver.auth.model.dto.response.RenewResponse;
+import com.matchday.matchdayserver.auth.service.GoogleOauthService;
+import com.matchday.matchdayserver.common.auth.JwtTokenProvider;
+import com.matchday.matchdayserver.common.auth.TokenHelper;
+import com.matchday.matchdayserver.common.exception.ApiException;
+import com.matchday.matchdayserver.common.response.JwtStatus;
+import com.matchday.matchdayserver.user.model.entity.User;
+import com.matchday.matchdayserver.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class UserOpenApiService {
+
+    private final TokenHelper tokenHelper;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public RenewResponse renewToken(HttpServletRequest request){
+        String refreshToken = getTokenFromRequest(request);
+        tokenHelper.validateToken(refreshToken, JwtTokenType.REFRESH);
+        Claims claims = tokenHelper.getClaims(refreshToken);
+
+        Map<String, Object> payload = new HashMap<>();
+        Long userId = Long.valueOf(claims.get("userId").toString());
+        String email = claims.getSubject();
+        String role = claims.get("role").toString();
+        payload.put("userId", userId);
+        payload.put("role", role);
+
+        //DB 조회로 사용자 상태 검증
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new ApiException(JwtStatus.NOTFOUND_USER));
+
+        String jwtAccessToken=jwtTokenProvider.createToken(email, payload, JwtTokenType.ACCESS);
+
+        return new RenewResponse(jwtAccessToken);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(GoogleOauthService.REFRESH_TOKEN_COOKIE_NAME)) {
+                refresh = cookie.getValue();
+            }
+        }
+        if (refresh == null) {
+            throw new ApiException(JwtStatus.NOTFOUND_TOKEN_IN_COOKIE);
+        }
+        return refresh;
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/user/service/UserOpenApiService.java
+++ b/src/main/java/com/matchday/matchdayserver/user/service/UserOpenApiService.java
@@ -32,7 +32,7 @@ public class UserOpenApiService {
 
         String accessToken=jwtTokenProvider.createToken(user, JwtTokenType.ACCESS);
         String refreshToken=jwtTokenProvider.createToken(user, JwtTokenType.REFRESH);
-        return new LoginResponse(accessToken,createCookie(refreshToken,REFRESH_TOKEN_COOKIE_NAME),
+        return new LoginResponse(accessToken,createCookie(REFRESH_TOKEN_COOKIE_NAME,refreshToken),
             user.getId());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,6 @@ decorator:
 
 jwt:
     secret: ${JWT_SECRET}
-    expiration: ${JWT_EXPIRATION}
 
 oauth:
     google:


### PR DESCRIPTION
## Related Issue

https://match-day.atlassian.net/browse/MAT-312

## Overview

🔒 MAT-312 – JWT 리프레시 토큰 적용

새로 추가된 기능
- JwtTokenProvider 개선
- 사용자 정보(User) 기반으로 accessToken, refreshToken 생성 메서드 분리 및 통합
- tokenType을 claim으로 명시해 타입 검증 가능
- TokenHelper 리팩토링
- 토큰 타입 (ACCESS, REFRESH) 명확히 구분하여 검증
- Authentication 객체를 직접 생성하여 Spring Security 인증 컨텍스트 설정
- JwtStatus 예외 케이스 추가
- 쿠키 없음, 토큰 타입 불일치 등 구체적인 오류 코드 (9007~9009) 정의
- 리프레시 토큰 쿠키 저장 로직 구현
- HttpOnly, Secure, Path("/") 옵션을 갖는 쿠키 생성
- OauthLoginResponse에서 refreshToken은 쿠키로만 전달하고 응답에서는 제외
- /open-api/v1/users/google 로그인 시 토큰 발급 & 쿠키 설정
- /open-api/v1/users/renew 리프레시 토큰 기반 액세스 토큰 재발급

💡 리팩토링/개선 사항
- Google OAuth 로그인 로직 개선
- 사용자 조회 및 신규 생성 로직 정리
- Token 생성 책임은 UserOpenApiService에서 처리
- 응답 DTO 정리 (LoginResponse, OauthLoginResponse, RenewResponse)
- 필요 필드만 포함해 프론트엔드에 필요한 데이터만 제공

🧪 테스트 포인트
- accessToken 만료 시 /renew 호출 → 새로운 토큰 정상 발급
- refreshToken 쿠키 누락 시 예외 응답 (NOTFOUND_COOKIE)
- 로그인 시 쿠키 정상 세팅 (HttpOnly, MaxAge 등)





