### PR TITLE
[MAT-370] ApiExceptionResponse 추가 및 에러 처리 로직에 ApiExceptionResponse로 변경

### DIFF
--- a/src/main/java/com/matchday/matchdayserver/common/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/matchday/matchdayserver/common/auth/CustomAccessDeniedHandler.java
@@ -1,6 +1,8 @@
 package com.matchday.matchdayserver.common.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.matchday.matchdayserver.common.exception.ApiExceptionInterface;
+import com.matchday.matchdayserver.common.response.ApiExceptionResponse;
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.common.response.AuthStatus;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,7 +42,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json;charset=UTF-8");
 
-        ApiResponse<?> body = ApiResponse.error(AuthStatus.FORBIDDEN);
+        ApiExceptionResponse<ApiExceptionInterface> body = ApiExceptionResponse.error(AuthStatus.FORBIDDEN);
 
         response.getWriter().write(objectMapper.writeValueAsString(body));
     }

--- a/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/matchday/matchdayserver/common/exception/ApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.common.exception;
 
+import com.matchday.matchdayserver.common.response.ApiExceptionResponse;
 import com.matchday.matchdayserver.common.response.ApiResponse;
 import com.matchday.matchdayserver.common.response.DefaultStatus;
 import lombok.extern.slf4j.Slf4j;
@@ -18,14 +19,14 @@ import java.util.List;
 public class ApiExceptionHandler {
 
     @ExceptionHandler(ApiException.class)
-    public ResponseEntity<ApiResponse<ApiExceptionInterface>> handleApiException(Exception ex, ApiException apiException) {
+    public ResponseEntity<ApiExceptionResponse<ApiExceptionInterface>> handleApiException(Exception ex, ApiException apiException) {
         return ResponseEntity.status(apiException.getStatus().getHttpStatusCode())
-                .body(ApiResponse.error(apiException.getStatus()));
+                .body(ApiExceptionResponse.error(apiException.getStatus()));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    public ApiResponse<List<String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+    public ApiExceptionResponse<List<String>> handleValidationExceptions(MethodArgumentNotValidException ex) {
         List<String> errorMessageList = ex.getFieldErrors()
             .stream()
             .map(
@@ -36,22 +37,22 @@ public class ApiExceptionHandler {
                 })
             .toList();
 
-        return ApiResponse.error(DefaultStatus.BAD_REQUEST,
+        return ApiExceptionResponse.error(DefaultStatus.BAD_REQUEST,
             errorMessageList); //400 에러 발생 후 각 검증 어노테이션에서 설정한 msg 출력
     }
 
     //PreAuthorize 실패했을때 예외처리 핸들링
     @ExceptionHandler(AuthorizationDeniedException.class)
     @ResponseStatus(HttpStatus.FORBIDDEN)
-    public ApiResponse<String> handleAuthorizationDeniedException(AuthorizationDeniedException ex) {
+    public ApiExceptionResponse<String> handleAuthorizationDeniedException(AuthorizationDeniedException ex) {
         log.warn("권한 거부: 타입=[{}], 메시지=[{}]", ex.getClass().getName(), ex.getMessage());
-        return ApiResponse.error(DefaultStatus.FORBIDDEN);
+        return ApiExceptionResponse.error(DefaultStatus.FORBIDDEN);
     }
 
     @ExceptionHandler(Exception.class)
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    public ApiResponse<String> handleAllExceptions(Exception ex) {
+    public ApiExceptionResponse<String> handleAllExceptions(Exception ex) {
       log.error("예외 발생: 타입=[{}], 메시지=[{}]", ex.getClass().getName(), ex.getMessage(), ex);
-      return ApiResponse.error(DefaultStatus.UNKNOWN_ERROR);
+      return ApiExceptionResponse.error(DefaultStatus.UNKNOWN_ERROR);
     }
 }

--- a/src/main/java/com/matchday/matchdayserver/common/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/com/matchday/matchdayserver/common/exception/WebSocketExceptionHandler.java
@@ -4,13 +4,14 @@ import java.io.IOException;
 import java.net.SocketException;
 import java.util.List;
 
+import com.matchday.matchdayserver.common.response.ApiExceptionResponse;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 
-import com.matchday.matchdayserver.common.response.ApiResponse;
+import com.matchday.matchdayserver.common.response.ApiExceptionResponse;
 import com.matchday.matchdayserver.common.response.DefaultStatus;
 import com.matchday.matchdayserver.common.response.MatchStatus;
 
@@ -37,23 +38,23 @@ public class WebSocketExceptionHandler {
   @MessageExceptionHandler(SocketException.class)
   // user prefix는 자동으로 붙음, 전체 유저에게 전송하고 싶으면 SendTo()를 써야함
   @SendToUser("/queue/errors")
-  public ApiResponse<ApiExceptionInterface> handleSocketException(Message<?> message) throws IOException {
+  public ApiExceptionResponse<ApiExceptionInterface> handleSocketException(Message<?> message) throws IOException {
     removeSession(message);
-    return ApiResponse.error(MatchStatus.SOCKET_ERROR);
+    return ApiExceptionResponse.error(MatchStatus.SOCKET_ERROR);
   }
 
   @MessageExceptionHandler(ApiException.class)
   @SendToUser("/queue/errors")
-  public ApiResponse<ApiExceptionInterface> handleApiException(ApiException exception) {
+  public ApiExceptionResponse<ApiExceptionInterface> handleApiException(ApiException exception) {
     log.error("WebSocket API Exception: {}", exception.getMessage());
-    return ApiResponse.error(exception.getStatus());
+    return ApiExceptionResponse.error(exception.getStatus());
   }
 
   @MessageExceptionHandler(Exception.class)
   @SendToUser("/queue/errors")
-  public ApiResponse<ApiExceptionInterface> handleGeneralException(Exception exception) {
+  public ApiExceptionResponse<ApiExceptionInterface> handleGeneralException(Exception exception) {
     log.error("WebSocket General Exception: {}", exception.getMessage());
-    return ApiResponse.error(DefaultStatus.UNKNOWN_ERROR);
+    return ApiExceptionResponse.error(DefaultStatus.UNKNOWN_ERROR);
   }
 
   private void removeSession(Message<?> message) throws IOException {

--- a/src/main/java/com/matchday/matchdayserver/common/response/ApiExceptionResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/ApiExceptionResponse.java
@@ -1,0 +1,40 @@
+package com.matchday.matchdayserver.common.response;
+
+import lombok.Getter;
+
+@Getter
+public class ApiExceptionResponse<T> extends ApiResponse<T> {
+
+    private int customStatusCode;
+
+    public ApiExceptionResponse(
+        StatusInterface status
+    ) {
+        super(
+            status.getHttpStatusCode(),
+            null,
+            status.getDescription()
+        );
+        this.customStatusCode = status.getCustomStatusCode();
+    }
+
+    public ApiExceptionResponse(
+        StatusInterface status,
+        T data
+    ) {
+        super(
+            status.getHttpStatusCode(),
+            data,
+            status.getDescription()
+        );
+        this.customStatusCode = status.getCustomStatusCode();
+    }
+
+    public static <T> ApiExceptionResponse<T> error(StatusInterface status) {
+        return new ApiExceptionResponse<>(status);
+    }
+
+    public static <T> ApiExceptionResponse<T> error(StatusInterface status, T data) {
+        return new ApiExceptionResponse<>(status, data);
+    }
+}

--- a/src/main/java/com/matchday/matchdayserver/common/response/ApiResponse.java
+++ b/src/main/java/com/matchday/matchdayserver/common/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.matchday.matchdayserver.common.response;
 
+import com.matchday.matchdayserver.common.exception.ApiException;
 import org.springframework.http.HttpStatus;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -28,12 +29,4 @@ public class ApiResponse<T> {
         return new ApiResponse<>(HttpStatus.CREATED.value(), data, DefaultStatus.OK.getDescription());
     }
 
-
-    public static <T> ApiResponse<T> error(StatusInterface status) {
-        return new ApiResponse<>(status.getCustomStatusCode(), null, status.getDescription());
-    }
-
-    public static <T> ApiResponse<T> error(StatusInterface status, T data) {
-        return new ApiResponse<>(status.getCustomStatusCode(), data, status.getDescription());
-    }
 }


### PR DESCRIPTION
## Related Issue

Related to : https://match-day.atlassian.net/jira/software/projects/MAT/boards/2?selectedIssue=MAT-370

## Overview

- 기존 에러 공통

```json
{
  "status": 400,
  "data": [
    "name : { null } 은 공백일 수 없습니다"
  ],
  "message": "Wrong Request",
}
```

- 변경 후 에러 공통

```json
{
  "status": 400,
  "data": [
    "name : { null } 은 공백일 수 없습니다"
  ],
  "message": "Wrong Request",
  "customStatusCode": 400
}
```
